### PR TITLE
Buoy stats and metrics:  wrapper scripts added

### DIFF
--- a/validation/runstats.py
+++ b/validation/runstats.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+runstats.py - sample driver for statistics and validation metric functions.
+"""
+
+import sys
+import copy
+from ww3stats   import ww3_pnt_stats
+from ww3metrics import ww3_pnt_metrics
+
+
+def main(argv):
+    '''
+    PURPOSE: Main for calling statistics and metrics functions.
+    USAGE:   python3 runstats.py <mod_buoy_colloc.nc> [ <ww3_param> [ <param_min> [ <param_max> ]]]
+    '''
+    args=sys.argv[1:]
+    vmin=0; vmax=20; parm='hs'
+    if   len(args) == 0:
+        sys.exit('python3 runstats.py <mod_buoy_colloc.nc> [ <ww3_param> [ <param_min> [ <param_max> ]]]')
+    elif len(args) == 1:
+        dat=copy.copy(args[0])
+    elif len(args) == 2:
+        dat=copy.copy(args[0]); parm=copy.copy(args[1])
+    elif len(args) == 3:
+        dat=copy.copy(args[0]); parm=copy.copy(args[1]); vmin=copy.copy(args[2])
+    elif len(args) == 4:
+        dat=copy.copy(args[0]); parm=copy.copy(args[1]); vmin=copy.copy(args[2]); vmax=copy.copy(args[3])
+    elif len(args)  > 4:
+        sys.exit('python3 runstats.py <mod_buoy_colloc.nc> [ <ww3_param> [ <param_min> [ <param_max> ]]]')
+
+
+    print('\n*  RUNSTATS  *\n')
+
+    print('\nCalling ww3_pnt_stats...')
+    ww3_pnt_stats(dat, parm, vmin, vmax)
+
+    print('\nCalling ww3_pnt_metrics...')
+    ww3_pnt_metrics(dat, parm, vmin, vmax)
+
+    print('\nRUNSTATS Complete.')
+
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/validation/ww3_run_stats.sh
+++ b/validation/ww3_run_stats.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# ww3_run_stats.sh
+# PURPOSE: shell script wrapper around python buoy collocation 
+#          and generation of statistics and metrics.
+#
+# USAGE:   ww3_run_stats.sh <ww3.tab.nc> [<var> [<var_min> [<var_max>]]]
+#
+export PATH=/scratch2/NCEPDEV/marine/Matthew.Masarik/wavpy/miniconda3/bin:${PATH}
+export PYTHONPATH=/scratch2/NCEPDEV/marine/Matthew.Masarik/wavpy/miniconda3/pkgs:${PYTHONPATH}
+
+usage_str='ww3_run_stats.sh <ww3.tab.nc> [<var> [<var_min> [<var_max>]]]'
+if [[ $# -lt 1 ]] || [[ $# -gt 4 ]]; then echo $usage_str; exit; fi
+
+ww3_tab="$1"
+shift
+if [ ! -f $ww3_tab ]; then
+    echo "file: $ww3_tab, not found"
+    exit
+fi
+echo -e "\nInput file: $ww3_tab"
+run_id=${ww3_tab%%.tab.*}
+run_id=${run_id#ww3.}
+
+ww3list=ww3list.txt
+if [ -f $ww3list ]; then rm -f $ww3list; fi
+touch $ww3list
+echo -e "$ww3_tab\n$ww3_tab" >> $ww3list
+
+
+# Buoy-model collocation
+buoy_colloc=$(ls -1 ww3buoy_collocation*.nc 2> /dev/null)
+if [ -f $buoy_colloc ]; then rm -f $buoy_colloc; fi
+echo 'Performing model-buoy collocation...'
+python3 modelBuoy_collocation_hindcast.py
+num_colloc=$(ls -1 ww3buoy_collocation*.nc | wc -l 2> /dev/null)
+if [ $num_colloc -ne 1 ]; then
+    echo "invalid num collocation files: ${num_colloc}."
+    exit
+fi
+buoy_colloc=$(ls -1 ww3buoy_collocation*.nc 2> /dev/null)
+
+
+# Statistics and metrics
+if [ -f stats_buoy*.txt  ]; then rm -f stats_buoy*.txt;  fi
+if [ -f stats_model*.txt ]; then rm -f stats_model*.txt; fi
+if [ -f metrics*.txt     ]; then rm -f metrics*.txt;     fi
+python3 runstats.py $buoy_colloc $@
+
+
+# Data mgmt
+mv $buoy_colloc  ${run_id}.${buoy_colloc}
+mv $ww3list      ${run_id}.${ww3list}
+
+if [ ! -f stats_buoy*.txt ]; then 
+    echo 'buoy stats not found.'
+else
+    buoy_stats=$(ls -1 stats_buoy*.txt)
+    mv $buoy_stats   ${run_id}.${buoy_stats}
+fi
+
+if [ ! -f stats_model*.txt ]; then 
+    echo 'model stats not found.'
+else
+    model_stats=$(ls -1 stats_model*.txt)
+    mv $model_stats   ${run_id}.${model_stats}
+fi
+
+if [ ! -f metrics*.txt ]; then 
+    echo 'metrics not found.'
+else
+    mod_buoy_mets=$(ls -1 metrics*.txt)
+    mv $mod_buoy_mets   ${run_id}.${mod_buoy_mets}
+fi
+
+echo -e "\nInput WW3 tab:      $ww3_tab\n"
+stats_out_dir=stats_out_$run_id
+mkdir $stats_out_dir
+if [ -d $stats_out_dir ]; then
+    mv -f ${run_id}.${buoy_colloc}   $stats_out_dir
+    mv -f ${run_id}.${ww3list}       $stats_out_dir
+    mv -f ${run_id}.${buoy_stats}    $stats_out_dir
+    mv -f ${run_id}.${model_stats}   $stats_out_dir
+    mv -f ${run_id}.${mod_buoy_mets} $stats_out_dir
+    echo -e "Output Directory:           ${stats_out_dir}/"
+fi
+echo -e "\tww3list:            ${run_id}.${ww3list}"
+echo -e "\tBuoy collocation:   ${run_id}.${buoy_colloc}"
+echo -e "\tBuoy stats:         ${run_id}.${buoy_stats}"
+echo -e "\tModel stats:        ${run_id}.${model_stats}"
+echo -e "\tValidation metrics: ${run_id}.${mod_buoy_mets}\n"
+

--- a/validation/ww3metrics.py
+++ b/validation/ww3metrics.py
@@ -16,7 +16,7 @@ def ww3_pnt_metrics(*args):
         PURPOSE: calculate validation metrics from buoy collocation input.
         USAGE:  ww3_pnt_metrics <mod_buoy_colloc.nc> [ <ww3_param> [ <param_min> [ <param_max> ]]]
         '''
-        vmin=-np.inf; vmax=np.inf; parm='hs'
+        vmin=0; vmax=20; parm='hs'
         if   len(args) == 0:
                 sys.exit('ww3_pnt_metrics <mod_buoy_colloc.nc> [ <ww3_param> [ <param_min> [ <param_max> ]]]')
         elif len(args) == 1:

--- a/validation/ww3stats.py
+++ b/validation/ww3stats.py
@@ -16,7 +16,7 @@ def ww3_pnt_stats(*args):
         PURPOSE: calculate summary statistics from buoy collocation input.
         USAGE:   ww3_pnt_stats <mod_buoy_colloc.nc> [ <ww3_param> [ <param_min> [ <param_max> ]]]
         '''
-        vmin=-np.inf; vmax=np.inf; parm='hs'
+        vmin=0; vmax=20; parm='hs'
         if   len(args) == 0:
                 sys.exit('ww3_pnt_stats <mod_buoy_colloc.nc> [ <ww3_param> [ <param_min> [ <param_max> ]]]')
         elif len(args) == 1:


### PR DESCRIPTION
# Pull Request Summary
Adds two wrapper scripts related to calculating summary statistics and validation metrics.  

## Description
The first script added is a `python` wrapper around the statistics and metrics function calls.  The second is a `bash` shell wrapper around the python script just mentioned, as well as the model-buoy collocation python script.  So, the end effect is:  1) the buoy collocation, 2) statistics, 3) metrics computations are all performed from a shell script.  The script takes one input, a WW3 point output '`tab`' file.  The identification string found between the initial `ww3.` and `.tab` in the filename are used as an output ID used for naming the output files and creating an output directory.

Please also include the following information: 
* Mention any labels that should be added:  _new feature_

### Issue(s) addressed
N/A

### Commit Message
buoy stats and metrics: python and bash wrapper scripts added

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
 
### Testing
* How were these changes tested?
  * First versions, so just lightweight testing:
    * Test was done for each script:  number of inputs, and validity of inputs were tested.
    * Metric and statistic output were confirmed to be the same as running each manually.


