### PR TITLE
add swden_ww3_read_ascii.m  examples/Example_Directional_Spectral_Den…

### DIFF
--- a/examples/Example_Directional_Spectral_Density_Jonswap_nc.m
+++ b/examples/Example_Directional_Spectral_Density_Jonswap_nc.m
@@ -87,7 +87,7 @@ end
 for i=1:length(freq)
     Q(1,i) = abs(trapz(0:pi*DeltaDir/180:2*pi-pi*DeltaDir/180,SPEC(:,i)));
 end
-coef=mean(Q.\S);
+coef=nanmean(Q.\S);
 Q=coef*Q;
 HScheck2=4.004*sqrt(trapz(2*pi*freq,Q))/sqrt(2*pi);
 SPEC=coef*SPEC;

--- a/examples/Example_Directional_Spectral_Density_Jonswap_nc.m
+++ b/examples/Example_Directional_Spectral_Density_Jonswap_nc.m
@@ -112,7 +112,7 @@ dpt=dpt*ones(1,length(time));
 display (['Generating ', filename,' ...'])
 %dump into netcdf
 [filename] = write_directional_spectra_nc(filename,testcase,...
-    pointID,Lat,Lon,dpt,wndspd,wnddir,curspd,curdir,time,freq,dir,EFTH,coordinate);
+    pointID,Lat,Lon,dpt,wndspd,wnddir,curspd,curdir,time,freq,dir0,EFTH,coordinate);
 %----------------------------------------------------------%         
 tf=strcmp(visualize,'true');                 
 if tf==1

--- a/examples/Example_Directional_Spectral_Density_Jonswap_nc.m
+++ b/examples/Example_Directional_Spectral_Density_Jonswap_nc.m
@@ -10,8 +10,8 @@ clc;
 % add path
 addpath ../ww3tools/matlab_tools
 %% input data %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-Hs=1;                      % significant wave height (m)                                                                         significant wave height (m)
-Tp=13;                     % peak period (s)                                                                       zero-crossing period (s)
+Hs=1;                      % significant wave height (m)                  
+Tp=13;                     % peak period (s)                              
 MeanDir=100;                % Mean Wave direction
 nfreq=35;                  % number of frequencies
 nDir=36;                   % number of Directions
@@ -145,7 +145,7 @@ xlim([freq(1) freq(end)])
 sss2=subplot(2,1,2);
 SPECC=EFTH(:,:,1,k);
 [~,cc] = polarPcolor(freq,[180*dir/pi 180*dir(1)/pi],...
-     [SPECC; SPECC(1,:)],'Nspokes',36,'ncolor',10,'labelR','f (Hz)');
+     [SPECC; SPECC(1,:)],'Nspokes',36,'ncolor',10,'labelR','f (Hz)','Rscale','log');
  ylabel(cc,['Date = ',datestr(time(k))],'FontSize',14);
 
 set(sss1, 'Position', [.08 .55 .88 .4]);

--- a/examples/Example_Directional_Spectral_Density_NDBC_nc.m
+++ b/examples/Example_Directional_Spectral_Density_NDBC_nc.m
@@ -1,0 +1,122 @@
+clear all;
+clc;
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% This script is an example convenrt ndbc spectral file into%
+% WW3 netcdf format                                         %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%      Ali Abdolali Feb 2023 ali.abdolali@noaa.gov          %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% add path
+addpath ../ww3tools/matlab_tools
+%% input data %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+nfreq=35;                  % number of frequencies
+nDir=36;                   % number of Directions
+Dir0=5;                    % first direction (deg)
+inc=1.1;                   % frequency increment
+f0=0.038; 
+filename='bnd_ndbc_ww3.nc';% name of netcdf file (boundary)
+testcase='DUCK';           % test vase
+pointID='44100';           % id (length should be 16)
+Lat=34.71;                 % latitude of BC (deg)
+Lon=-72.248;               % longitude of BC (deg)
+dpt=26;                    % Depth of BC (m)
+wndspd=0;                  % wind speed (m/s)
+wnddir=270;                % wind direction (deg)
+curspd=0;                  % current velocity (m/s)
+curdir=270;                % current direction (deg)
+coordinate='spherical';    % coordinate : Spherical, cartesian
+ncf='44100w9999.nc';       % input netcdf file from https://dods.ndbc.noaa.gov/
+visualize='true';          % options:true, false- this requires polarPcolor function and can be obtained from ...
+                           % https://www.mathworks.com/matlabcentral/fileexchange/49040-pcolor-in-polar-coordinates
+deltatheta=10;             % DeltaDir
+theta0=0;                  % first Dir
+%----------------------------------------------------------%
+% if visualize='true', user can define the time frame to visualize
+t1=(datenum('20221201 000000','yyyymmdd HHMMSS')); % first timestep 
+t2=(datenum('20221202 000000','yyyymmdd HHMMSS')); % last timestep 
+dt=1/24;                      %delta t (day)
+%----------------------------------------------------------%
+% frequency (log)
+Omega(1)=2*pi*f0;
+for i=2:nfreq
+Omega(i)=inc*Omega(i-1);
+end
+freq=Omega/2/pi;
+%----------------------------------------------------------%
+display (['Reading ', ncf,' ...'])
+% read input netcdf file (directional spectral density file)
+[SWDEN] = swden_ndbc_read(ncf,deltatheta,theta0,freq);
+%----------------------------------------------------------%
+% The boundary requres coordinates (lat, lon) depth, wind speed
+% wind direction, current speed, current direction for each time step.
+% Here wind and current are 0.
+pointID = [pointID,repmat(' ', [1, 16-strlength(pointID)])];
+Lon=Lon*ones(1,length(SWDEN.Int.time));
+Lat=Lat*ones(1,length(SWDEN.Int.time));
+curspd=curspd*ones(1,length(SWDEN.Int.time));
+curdir=curdir*ones(1,length(SWDEN.Int.time));
+wndspd=wndspd*ones(1,length(SWDEN.Int.time));
+wnddir=wnddir*ones(1,length(SWDEN.Int.time));
+dpt=dpt*ones(1,length(SWDEN.Int.time));
+time(1,:)=SWDEN.Int.time;
+dir=pi*SWDEN.Int.Dir/180; %radian
+EFTH(:,:,1,:)=SWDEN.Int.DENS; %directional spectral density time series
+%----------------------------------------------------------%
+display (['Generating ', filename,' ...'])
+%dump into netcdf
+[filename] = write_directional_spectra_nc(filename,testcase,...
+            pointID,Lat,Lon,dpt,wndspd,wnddir,curspd,curdir,time,...
+            SWDEN.Int.f,dir,EFTH,coordinate);
+        
+ 
+%%
+%----------------------------------------------------------%        
+tf=strcmp(visualize,'true');                 
+if tf==1
+display (['Plot Generation ', [filename,'.gif'],' ...'])
+width=1200;  % Width of figure for movie [pixels]
+height=500;  % Height of figure of movie [pixels]
+left=200;     % Left margin between figure and screen edge [pixels]
+bottom=200;  % Bottom margin between figure and screen edge [pixels]
+
+DENSOrig(:,:,:)=SWDEN.Orig.DENS(:,:,:);
+DENSInt(:,:,:)=SWDEN.Int.DENS(:,:,:);
+t=t1:dt:t2;
+h=figure;
+set(gcf,'Position', [left bottom width height])
+
+for k=1:1:length(t)
+    clf
+ subplot(1,2,1)
+ 
+ [it]=find(abs(SWDEN.Orig.time-t(k))==min((abs(SWDEN.Orig.time-t(k)))));
+ clear DENSS
+ DENSS(:,:)=DENSOrig(:,:,it(1),:);
+ DENSStmp=[DENSS;DENSS(1,:)];
+ [~,cc] = polarPcolor(SWDEN.Orig.f,[SWDEN.Orig.Dir SWDEN.Orig.Dir(1)],...
+     DENSStmp,'Nspokes',36,'ncolor',10,'labelR','f (Hz)','Rscale','log');
+ ylabel(cc,['Obs (Original); Date = ',datestr(SWDEN.Orig.time(it(1)))],'FontSize',14);
+caxis([0 nanmax(DENSS(:))])
+ subplot(1,2,2)
+ clear DENSS
+ DENSS(:,:)=DENSInt(:,:,it(1),:);
+ DENSStmp=[DENSS;DENSS(1,:)];
+ [~,cc] = polarPcolor(SWDEN.Int.f,[SWDEN.Int.Dir SWDEN.Int.Dir(1)],...
+     DENSStmp,'Nspokes',36,'ncolor',10,'labelR','f (Hz)','Rscale','log');
+ ylabel(cc,['Obs (Interpolated); Date = ',datestr(SWDEN.Orig.time(it(1)))],'FontSize',14);
+caxis([0 nanmax(DENSS(:))])
+
+  frame = getframe(h);
+    im = frame2im(frame);
+    [imind,cm] = rgb2ind(im,256);
+    
+    if k == 1
+        imwrite(imind,cm,[filename,'.gif'],'gif', 'Loopcount',inf);
+    else
+        imwrite(imind,cm,[filename,'.gif'],'gif','WriteMode','append');
+    end   
+end 
+end
+%----------------------------------------------------------%         
+display (['Finished'])

--- a/examples/Example_Directional_Spectral_Density_NDBC_nc.m
+++ b/examples/Example_Directional_Spectral_Density_NDBC_nc.m
@@ -61,13 +61,14 @@ wnddir=wnddir*ones(1,length(SWDEN.Int.time));
 dpt=dpt*ones(1,length(SWDEN.Int.time));
 time(1,:)=SWDEN.Int.time;
 dir=pi*SWDEN.Int.Dir/180; %radian
+dir0=SWDEN.Int.Dir;%degree
 EFTH(:,:,1,:)=SWDEN.Int.DENS; %directional spectral density time series
 %----------------------------------------------------------%
 display (['Generating ', filename,' ...'])
 %dump into netcdf
 [filename] = write_directional_spectra_nc(filename,testcase,...
             pointID,Lat,Lon,dpt,wndspd,wnddir,curspd,curdir,time,...
-            SWDEN.Int.f,dir,EFTH,coordinate);
+            SWDEN.Int.f,dir0,EFTH,coordinate);
         
  
 %%

--- a/ww3tools/matlab_tools/swden_ndbc_read.m
+++ b/ww3tools/matlab_tools/swden_ndbc_read.m
@@ -1,4 +1,4 @@
-function [SWDEN] = swden_ndbc_read(ncf,deltatheta,freq)
+function [SWDEN] = swden_ndbc_read(ncf,deltatheta,theta0,freq)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % This function reads NDBC directional spectral density file%
 % netcdf format from https://dods.ndbc.noaa.gov/            %
@@ -9,6 +9,7 @@ function [SWDEN] = swden_ndbc_read(ncf,deltatheta,freq)
 %  input data %--------------------------------------------%
 % ncf: name of netcdf file
 % deltatheta: direction resolution (degree)
+% theta0: first dir (degree)
 % freq: Frequency for interpolation (Hz)
 %  output data %--------------------------------------------%
 %There are two outputs: 
@@ -35,7 +36,7 @@ alpha1=ncread(ncf,'mean_wave_dir');
 a1(:,:)=alpha1(1,1,:,:);
 alpha2=ncread(ncf,'principal_wave_dir');
 a2(:,:)=alpha2(1,1,:,:);
-theta(1,:)=[90:-deltatheta:0 360-deltatheta:-deltatheta:90+deltatheta];
+theta(1,:)=[90-theta0:-deltatheta:0+theta0 360+theta0-deltatheta:-deltatheta:90+deltatheta-theta0];
 Hs(:,1)=4.004*sqrt(abs(trapz(2*pi*f,SPEC(:,:))))/sqrt(2*pi);
 
 SPECmax=nanmax(SPEC);

--- a/ww3tools/matlab_tools/swden_ww3_read.m
+++ b/ww3tools/matlab_tools/swden_ww3_read.m
@@ -19,6 +19,12 @@ function [SWDEN] = swden_ww3_read(ncf)
 % SPEC: Spectral Density [freq,stations,time]
 % Hs: Significant Wave Heigth (m)
 % Fp: Peak Freq (Hz)
+% cur: current speed (m/s)
+% curdir: current direction (deg)
+% wnd: wind speed (m/s)
+% wnddir: wind direction (deg)
+% dpt: depth (m)
+
 %----------------------------------------------------------%
 SWDEN.buoy_name=cellstr(flipud(rot90(ncread(ncf,'station_name'))));
 SWDEN.time=convert_time(ncf,'time');
@@ -27,21 +33,27 @@ SWDEN.longitude=ncread(ncf,'longitude');
 SWDEN.f=double(ncread(ncf,'frequency'));
 SWDEN.Dir=ncread(ncf,'direction');
 SWDEN.DENS=ncread(ncf,'efth');
+SWDEN.cur=ncread(ncf,'cur');
+SWDEN.curdir=ncread(ncf,'curdir');
+SWDEN.wnd=ncread(ncf,'wnd');
+SWDEN.wnddir=ncread(ncf,'wnddir');
+SWDEN.dpt=ncread(ncf,'dpt');
 DeltaDir=abs(SWDEN.Dir(2)-SWDEN.Dir(1));
 DENS=SWDEN.DENS;
 DENS=[DENS; DENS(1,:,:,:)];
-for k=1:length(SWDEN.buoy_name)
-for ii=1:length(SWDEN.f)
-    SPEC(ii,k,:) = abs(trapz(0:pi*DeltaDir/180:2*pi,DENS(:,ii,k,:)));
+[DD,FF,KK,TT]=size(SWDEN.DENS);
+for k=1:KK
+for ii=1:FF
+SPEC(ii,k,:) = abs(trapz(0:pi*DeltaDir/180:2*pi,DENS(:,ii,k,:)));
 end
 end
 SWDEN.SPEC=SPEC;
-for k=1:length(SWDEN.buoy_name)
+for k=1:KK
  Hs(k,:)=4.004*sqrt(abs(trapz(2*pi*SWDEN.f,SPEC(:,k,:))))/sqrt(2*pi);
 end
  SWDEN.Hs=Hs;
 
-for k=1:length(SWDEN.buoy_name)
+for k=1:KK
     clear SPECmax
     clear SPECtmp
     SPECtmp(:,:)=SPEC(:,k,:);

--- a/ww3tools/matlab_tools/swden_ww3_read.m
+++ b/ww3tools/matlab_tools/swden_ww3_read.m
@@ -19,6 +19,7 @@ function [SWDEN] = swden_ww3_read(ncf)
 % SPEC: Spectral Density [freq,stations,time]
 % Hs: Significant Wave Heigth (m)
 % Fp: Peak Freq (Hz)
+% mwvdir: mean wave direction (degrees)
 % cur: current speed (m/s)
 % curdir: current direction (deg)
 % wnd: wind speed (m/s)
@@ -42,17 +43,24 @@ DeltaDir=abs(SWDEN.Dir(2)-SWDEN.Dir(1));
 DENS=SWDEN.DENS;
 DENS=[DENS; DENS(1,:,:,:)];
 [DD,FF,KK,TT]=size(SWDEN.DENS);
+
+DENSCOS=cosd([SWDEN.Dir;SWDEN.Dir(1)]).*DENS;
+DENSSIN=sind([SWDEN.Dir;SWDEN.Dir(1)]).*DENS;
 for k=1:KK
 for ii=1:FF
 SPEC(ii,k,:) = abs(trapz(0:pi*DeltaDir/180:2*pi,DENS(:,ii,k,:)));
+SPECA(ii,k,:) = (trapz(0:pi*DeltaDir/180:2*pi,DENSCOS(:,ii,k,:)));
+SPECB(ii,k,:) = (trapz(0:pi*DeltaDir/180:2*pi,DENSSIN(:,ii,k,:)));
 end
 end
 SWDEN.SPEC=SPEC;
 for k=1:KK
  Hs(k,:)=4.004*sqrt(abs(trapz(2*pi*SWDEN.f,SPEC(:,k,:))))/sqrt(2*pi);
+ AA(k,:)=((trapz(2*pi*SWDEN.f,SPECA(:,k,:))));
+ BB(k,:)=((trapz(2*pi*SWDEN.f,SPECB(:,k,:))));
 end
  SWDEN.Hs=Hs;
-
+ SWDEN.mwvdir=(180*atan2(BB,AA)/pi)+180;
 for k=1:KK
     clear SPECmax
     clear SPECtmp

--- a/ww3tools/matlab_tools/swden_ww3_read_ascii.m
+++ b/ww3tools/matlab_tools/swden_ww3_read_ascii.m
@@ -19,6 +19,7 @@ function [SWDEN] = swden_ww3_read_ascii(specfile)
 % SPEC: Spectral Density [freq,stations,time]
 % Hs: Significant Wave Heigth (m)
 % Fp: Peak Freq (Hz)
+% mwvdir: mean wave direction (degrees)
 % cur: current speed (m/s)
 % curdir: current direction (deg)
 % wnd: wind speed (m/s)
@@ -106,16 +107,25 @@ DeltaDir=abs(SWDEN.Dir(2)-SWDEN.Dir(1));
 DENS=SWDEN.DENS;
 DENS=[DENS; DENS(1,:,:,:)];
 [DD,FF,KK,TT]=size(SWDEN.DENS);
+
+DENSCOS=cosd([SWDEN.Dir;SWDEN.Dir(1)]).*DENS;
+DENSSIN=sind([SWDEN.Dir;SWDEN.Dir(1)]).*DENS;
+
 for k=1:KK
 for ii=1:FF
 SPEC(ii,k,:) = abs(trapz(0:pi*DeltaDir/180:2*pi,DENS(:,ii,k,:)));
+SPECA(ii,k,:) = (trapz(0:pi*DeltaDir/180:2*pi,DENSCOS(:,ii,k,:)));
+SPECB(ii,k,:) = (trapz(0:pi*DeltaDir/180:2*pi,DENSSIN(:,ii,k,:)));
 end
 end
 SWDEN.SPEC=SPEC;
 for k=1:KK
  Hs(k,:)=4.004*sqrt(abs(trapz(2*pi*SWDEN.f,SPEC(:,k,:))))/sqrt(2*pi);
+ AA(k,:)=((trapz(2*pi*SWDEN.f,SPECA(:,k,:))));
+ BB(k,:)=((trapz(2*pi*SWDEN.f,SPECB(:,k,:))));
 end
  SWDEN.Hs=Hs;
+ SWDEN.mwvdir=(180*atan2(BB,AA)/pi)+180;
 
 for k=1:KK
     clear SPECmax

--- a/ww3tools/matlab_tools/swden_ww3_read_ascii.m
+++ b/ww3tools/matlab_tools/swden_ww3_read_ascii.m
@@ -1,0 +1,132 @@
+function [SWDEN] = swden_ww3_read_ascii(specfile)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% This function reads WW3 directional spectral density file %
+% .spec asill format                                        %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%      Ali Abdolali Feb 2023 ali.abdolali@noaa.gov          %
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%  input data %--------------------------------------------%
+% specfile: name of .spec file
+%  output data %--------------------------------------------%
+% buoy_name: list of buoy
+% time (Matlab time)
+% longitude of points (Degree)
+% latitude of points (Degree)
+% f: frequency (Hz)
+% Dir: direction (degree)
+% DENS: Directional Spectral Density [freq,direction,stations,time]
+% SPEC: Spectral Density [freq,stations,time]
+% Hs: Significant Wave Heigth (m)
+% Fp: Peak Freq (Hz)
+% cur: current speed (m/s)
+% curdir: current direction (deg)
+% wnd: wind speed (m/s)
+% wnddir: wind direction (deg)
+% dpt: depth (m)
+
+%----------------------------------------------------------%
+m=0;
+%read and put all lines into cells
+fid = fopen(specfile,'rt');
+tline = fgetl(fid);
+while ischar(tline)
+m=m+1;
+     file{m}=(tline);
+    tline = fgetl(fid);
+end
+fclose(fid);
+%----------------------------------------------------------%
+freq=[];
+Dir=[];
+%'---------------------'    nfreq nDir   nstation '------------------------'
+%'WAVEWATCH III SPECTRA'     50    36     1 'spectral resolution for points'
+C = textscan(file{1},'%s %s %s %n %n %n %s %s %s %s');
+nfreq=C{4};
+nDir=C{5};
+nStation=C{6};
+  i=1;
+    while length(freq)<nfreq
+        i=i+1;
+        A=cell2mat(textscan(file{i}, '%n', 'delimiter', '\n', 'whitespace', ' '));
+    freq=[freq;A];
+    end
+%----------------------------------------------------------%    
+  while length(Dir)<nDir
+        i=i+1;
+        A=cell2mat(textscan(file{i}, '%n', 'delimiter', '\n', 'whitespace', ' '));
+    Dir=[Dir;A];
+  end
+%----------------------------------------------------------%
+%go through time loop
+  m=1;
+   while i<length(file)
+  i=i+1;
+      time(m,1) = datenum(file{i},'yyyymmdd HHMMSS');
+   i=i+1;
+% buoyname  '  lat    long       dpt     wnd  wnddir cur  curdir   
+%'46069     '  33.65-120.20     919.8   5.10  30.0   0.38 356.0
+    C=textscan(file{i}, '%s %s %n %n %n %n %n %n %n %*[^\n]');
+    buoy_name=C{1};
+    lat(1,m)=C{3};
+    lon(1,m)=C{4};
+    dpt(1,m)=C{5};
+    wnd(1,m)=C{6};
+    wnddir(1,m)=C{7};
+    cur(1,m)=C{8};
+    curdir(1,m)=C{9};
+%----------------------------------------------------------%    
+  dens=[];
+    while length(dens)<nDir*nfreq
+        i=i+1;
+        A=cell2mat(textscan(file{i}, '%n', 'delimiter', '\n', 'whitespace', ''));
+    dens=[dens; A];
+    end
+  denstmp(1,:)=dens;
+  DENS(:,:,nStation,m)=fliplr(reshape(dens,[nDir,nfreq]));
+   m=m+1;
+   end
+  
+   
+   
+SWDEN.buoy_name=cellstr(buoy_name);
+SWDEN.time=time;
+SWDEN.latitude=lat;
+SWDEN.longitude=lon;
+SWDEN.f=freq;
+SWDEN.Dir=round(Dir*180/pi);%precision is not enough in spec
+SWDEN.DENS=DENS;
+SWDEN.cur=cur;
+SWDEN.curdir=curdir;
+SWDEN.wnd=wnd;
+SWDEN.wnddir=wnddir;
+SWDEN.dpt=dpt;
+DeltaDir=abs(SWDEN.Dir(2)-SWDEN.Dir(1)); 
+%DeltaDir
+DENS=SWDEN.DENS;
+DENS=[DENS; DENS(1,:,:,:)];
+[DD,FF,KK,TT]=size(SWDEN.DENS);
+for k=1:KK
+for ii=1:FF
+SPEC(ii,k,:) = abs(trapz(0:pi*DeltaDir/180:2*pi,DENS(:,ii,k,:)));
+end
+end
+SWDEN.SPEC=SPEC;
+for k=1:KK
+ Hs(k,:)=4.004*sqrt(abs(trapz(2*pi*SWDEN.f,SPEC(:,k,:))))/sqrt(2*pi);
+end
+ SWDEN.Hs=Hs;
+
+for k=1:KK
+    clear SPECmax
+    clear SPECtmp
+    SPECtmp(:,:)=SPEC(:,k,:);
+    SPECmax=nanmax(SPECtmp);
+for i=1:length(SWDEN.time)
+    clear i1
+    clear j1
+    [i1,j1]=find(SPECtmp(:,i)==SPECmax(i));
+    Fp(k,i)=nanmean(SWDEN.f(i1));
+end
+SWDEN.Fp=Fp;    
+end

--- a/ww3tools/matlab_tools/write_directional_spectra_ascii.m
+++ b/ww3tools/matlab_tools/write_directional_spectra_ascii.m
@@ -33,7 +33,7 @@ function [filename] = write_directional_spectra_ascii(filename,testcase,...
 %'inlet','B42001',42,221.1,1521,30,270,0.5,36,time,freq,dir,EF)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 [nDir,nfreq,pointnumber,ntime]=size(EF);
-
+formatOut='yyyymmdd HHMMSS';
 
 fileID = fopen([filename,'.spc'],'w');
 fprintf(fileID,'%s     %d    %d     %d %s\n', 'WAVEWATCH III SPECTRA',...


### PR DESCRIPTION
This PR add a new function to read spec files in ascii format with a corresponding example to check its functionality. 
- ww3tools/matlab_tools/swden_ww3_read_ascii.m
- examples/Example_Directional_Spectral_Density_NDBC_ascii.m
In addition, a couple of files and examples are modified to accomodate some small features like log scale on polar plots, modularities, ... 

Please also include the following information: 
* Add any suggestions for a reviewer  @MatthewMasarik-NOAA @ricampos 
* Mention any labels that should be added:  _enhancement_

### Commit Message
add swden_ww3_read_ascii.m (read spec file in WW3 ascii format)
### Check list  

- [ x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
 
### Testing

* How were these changes tested?
The  examples/Example_Directional_Spectral_Density_NDBC_ascii.m checks the functionality of the new feature.

