### PR TITLE
Added a switch for downsampling of data for scatterplot

### DIFF
--- a/ww3tools/pvalstats.py
+++ b/ww3tools/pvalstats.py
@@ -119,10 +119,10 @@ from matplotlib.dates import DateFormatter
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import os
-#from mpl_toolkits.basemap import cm
-#colormap = cm.GMT_polar
-#palette = plt.cm.jet
-#palette.set_bad('aqua', 10.0)
+from mpl_toolkits.basemap import cm
+colormap = cm.GMT_polar
+palette = plt.cm.jet
+palette.set_bad('aqua', 10.0)
 import warnings; warnings.filterwarnings("ignore")
 # Font size and style
 sl=13

--- a/ww3tools/pvalstats.py
+++ b/ww3tools/pvalstats.py
@@ -449,80 +449,89 @@ class ModelObsPlot:
           mop.scatterplot()
         '''
 
-        if self.obs[0,:].shape[0]>50000:
-            sk=int(np.round(np.float(self.obs[0,:].shape[0])/30000.,0))
-        else:
-            sk=1
+        num_points_plotted = 0  # Initialize counter
 
-        a=math.floor(np.nanmin(np.append(self.obs[:,::sk],self.model[:,::sk]))*100.)/100. ; b=math.ceil(np.nanmax(np.append(self.obs[:,::sk],self.model[:,::sk]))*100.)/100.
-        famin=a-0.1*a; famax=b+0.1*a
-        aux=np.linspace(famin,famax,100); del a,b
-
+        a = math.floor(np.nanmin(np.append(self.obs, self.model)) * 100.) / 100.
+        b = math.ceil(np.nanmax(np.append(self.obs, self.model)) * 100.) / 100.
+        famin = a - 0.1 * a
+        famax = b + 0.1 * a
+        aux = np.linspace(famin, famax, 100)
+        
         # plot
-        fig1 = plt.figure(1,figsize=(5,4.5)); ax = fig1.add_subplot(111)
+        fig1 = plt.figure(1, figsize=(5, 4.5))
+        ax = fig1.add_subplot(111)
 
-        for i in range(0,self.model.shape[0]):
-            b=np.array(self.obs[0,::sk]); a=np.array(self.model[i,::sk])
-            ind=np.where((a*b)>-999.)[0]; a=np.copy(a[ind]); b=np.copy(b[ind]); del ind
+        for i in range(0, self.model.shape[0]):
+            b = np.array(self.obs)
+            a = np.array(self.model[i])
 
-            if (a.shape[0]<30) | (self.model.shape[0]>1):
-                if np.size(self.mlabels)>0:
+            num_points_plotted += len(a)
+
+            if (a.shape[0] < 30) or (self.model.shape[0] > 1):
+                if np.size(self.mlabels) > 0:
                     if self.mlabels[0] != '':
-                        ax.scatter(b,a,color=self.color[i],marker=self.marker[i],label=self.mlabels[i],zorder=2)
+                        ax.scatter(b, a, color=self.color[i], marker=self.marker[i], label=self.mlabels[i], zorder=2)
                     else:
-                        ax.scatter(b,a,color=self.color[i],marker=self.marker[i],zorder=2)
-
+                        ax.scatter(b, a, color=self.color[i], marker=self.marker[i], zorder=2)
                 else:
-                    ax.scatter(b,a,color=self.color[i],marker=self.marker[i],zorder=2)
-
-            elif (np.size(self.color)==1) & (self.model.shape[0]==1):
-                ax.scatter(b,a,color=self.color[i],marker=self.marker[i],zorder=2)
-
+                    ax.scatter(b, a, color=self.color[i], marker=self.marker[i], zorder=2)
+            elif (np.size(self.color) == 1) & (self.model.shape[0] == 1):
+                ax.scatter(b, a, color=self.color[i], marker=self.marker[i], zorder=2)
             else:
-                xy = np.vstack([a,b]); z = gaussian_kde(xy)(xy)
-                if np.size(self.mlabels)>0:
+                xy = np.vstack([a, b])
+                z = gaussian_kde(xy)(xy)
+                if np.size(self.mlabels) > 0:
                     if self.mlabels[0] != '':
-                        ax.scatter(b,a, c=z, s=5,cmap=plt.cm.jet,label=self.mlabels[i],zorder=2)
+                        ax.scatter(b, a, c=z, s=5, cmap=plt.cm.jet, label=self.mlabels[i], zorder=2)
                     else:
-                        ax.scatter(b,a, c=z, s=5,cmap=plt.cm.jet,zorder=2)
-
+                        ax.scatter(b, a, c=z, s=5, cmap=plt.cm.jet, zorder=2)
                 else:
-                    ax.scatter(b,a, c=z, s=5,cmap=plt.cm.jet,zorder=2)
+                    ax.scatter(b, a, c=z, s=5, cmap=plt.cm.jet, zorder=2)
 
             if self.linreg:
-                r = linregress(b,a)
-                aregr = np.array(r.slope*aux + r.intercept )
-                ax.plot(aux,aregr,color=self.color[i],ls='-',linewidth=1.,alpha=0.8,zorder=4)
-                ax.plot(aux,aregr,color='k',ls=':',linewidth=0.7,alpha=0.7,zorder=4)
-                if np.size(self.mlabels)>0:
-                    print(self.ftag+"ScatterPlot "+self.mlabels[i]+": Slope "+np.str(np.round(float(r.slope),5))+", Intercept "+np.str(np.round(float(r.intercept),5)))
+                r = linregress(b, a)
+                aregr = np.array(r.slope * aux + r.intercept)
+                ax.plot(aux, aregr, color=self.color[i], ls='-', linewidth=1., alpha=0.8, zorder=4)
+                ax.plot(aux, aregr, color='k', ls=':', linewidth=0.7, alpha=0.7, zorder=4)
+                if np.size(self.mlabels) > 0:
+                    print(self.ftag + "ScatterPlot " + self.mlabels[i] + ": Slope " + np.str(
+                        np.round(float(r.slope), 5)) + ", Intercept " + np.str(np.round(float(r.intercept), 5)))
                 else:
-                    print(self.ftag+"ScatterPlot: Slope "+np.str(np.round(float(r.slope),5))+", Intercept "+np.str(np.round(float(r.intercept),5)))                      
+                    print(self.ftag + "ScatterPlot: Slope " + np.str(np.round(float(r.slope), 5)) + ", Intercept " + np.str(
+                        np.round(float(r.intercept), 5)))
+                del r, aregr
 
-                del r,aregr
+            del a, b
 
-            del a,b
+        ax.plot(aux, aux, 'k--', linewidth=1., alpha=0.9, zorder=3)  # main diagonal
+        plt.locator_params(axis='y', nbins=7)
+        plt.locator_params(axis='x', nbins=7)
 
-        ax.plot(aux,aux,'k--', linewidth=1.,alpha=0.9,zorder=3)  # main diagonal
-        plt.locator_params(axis='y', nbins=7) ; plt.locator_params(axis='x', nbins=7)
+        ax.set_xlabel(self.axisnames[1])
+        ax.set_ylabel(self.axisnames[0])
 
-        ax.set_xlabel(self.axisnames[1]); ax.set_ylabel(self.axisnames[0])
+        plt.grid(c='grey', ls=':', alpha=0.5, zorder=1)
+        for i in np.array([50, 80, 95, 99]):
+            plt.axvline(x=np.nanpercentile(self.obs, int(i)), ls='--', color='grey', linewidth=1., alpha=0.7, zorder=1)
+            plt.text(np.nanpercentile(self.obs, int(i)), ((famax - famin) / 15) + famin, str(int(i)) + 'th', color='dimgrey',
+                     fontsize=sl - 7, zorder=4)
+            plt.text(np.nanpercentile(self.obs, int(i)), ((famax - famin) / 1.05) + famin, str(int(i)) + 'th',
+                     color='dimgrey', fontsize=sl - 7, zorder=4)
 
-        plt.grid(c='grey', ls=':', alpha=0.5,zorder=1)
-        for i in np.array([50,80,95,99]):
-            plt.axvline(x= np.nanpercentile(self.obs,int(i)),ls='--',color='grey',linewidth=1.,alpha=0.7,zorder=1)
-            plt.text(np.nanpercentile(self.obs,int(i)),((famax-famin)/15)+famin,str(int(i))+'th',color='dimgrey',fontsize=sl-7,zorder=4)
-            plt.text(np.nanpercentile(self.obs,int(i)),((famax-famin)/1.05)+famin,str(int(i))+'th',color='dimgrey',fontsize=sl-7,zorder=4)
+        plt.gca().set_xlim(left=famin, right=famax)
+        plt.gca().set_ylim(ymin=famin, ymax=famax)
 
-        plt.gca().set_xlim(left=famin, right=famax); plt.gca().set_ylim(ymin=famin,ymax=famax)
-
-        if np.size(self.mlabels)>0:
+        if np.size(self.mlabels) > 0:
             if self.mlabels[0] != '':
-                plt.legend(loc="upper left",fontsize=sl-2)
+                plt.legend(loc="upper left", fontsize=sl - 2)
 
         plt.tight_layout()
-        plt.savefig(self.ftag+'ScatterPlot.png', dpi=200, facecolor='w', edgecolor='w',orientation='portrait', format='png',transparent=False, bbox_inches='tight', pad_inches=0.1)
-        plt.close(fig1); del fig1, ax
+        plt.savefig(self.ftag + 'ScatterPlot.png', dpi=200, facecolor='w', edgecolor='w', orientation='portrait',
+                    format='png', transparent=False, bbox_inches='tight', pad_inches=0.1)
+        plt.close(fig1)
+        del fig1, ax
+
+        print("Number of data points plotted:", num_points_plotted)
 
     def taylordiagram(self):
         '''


### PR DESCRIPTION
## Description
This PR includes changes related to PR #62.

### Details
In this PR, a switch is added to the code to be able to either do down-sampling or keep the actual number of data points. This PR is a modification to PR #62 which removed the down-sampling capability. But with this PR, the user can decide to either have the down-sampling or not. 

### Cherry-Picked Commit
The changes in this PR include a commit that was cherry-picked from another branch. Specifically, commit `11f448c` from the `pval-scatterp` branch was cherry-picked to address the capability to switch between doing down sampling or not.

