### PR TITLE
Remove Basemap dependency

### DIFF
--- a/ww3tools/organizeDistanceToCoast.py
+++ b/ww3tools/organizeDistanceToCoast.py
@@ -36,12 +36,8 @@ import numpy as np
 from matplotlib.mlab import *
 from pylab import *
 import matplotlib.pyplot as plt
-from mpl_toolkits.basemap import cm
 from netCDF4 import Dataset
 import warnings; warnings.filterwarnings("ignore")
-colormap = cm.GMT_polar
-palette = plt.cm.jet
-palette.set_bad('aqua', 10.0)
 # netcdf format
 fnetcdf="NETCDF4"
 

--- a/ww3tools/pvalstats.py
+++ b/ww3tools/pvalstats.py
@@ -119,11 +119,8 @@ from matplotlib.dates import DateFormatter
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import os
-from mpl_toolkits.basemap import cm
-colormap = cm.GMT_polar
-palette = plt.cm.jet
-palette.set_bad('aqua', 10.0)
 import warnings; warnings.filterwarnings("ignore")
+
 # Font size and style
 sl=13
 matplotlib.rcParams.update({'font.size': sl}); plt.rc('font', size=sl) 


### PR DESCRIPTION
## Description
This PR removes the Basemap dependency from the code. Basemap is being deprecated because Cartopy provides similar functionality for plotting geographic data. 

### Changes
Removed Basemap import statement and associated code. 
### Cherry-Picked Commit
The changes in this PR include a commit that was cherry-picked from another branch. Specifically, commit '331865e' from "pval-basemap" branch was cherry-picked to address the basemap removal from both pvalstats.py and organizeDistanceToCoast.py.

## Explanation 

- Basemap functionality has been replaced with equivalent functionality from Cartopy.

- The code remains fully functional and produces the same visual output without relying on Basemap.