### PR TITLE
Adding the mesh refinement based on polygon and adding the config.ini…

### DIFF
--- a/unst_msh_gen/README.md
+++ b/unst_msh_gen/README.md
@@ -3,7 +3,7 @@ Unstructured mesh generation for WW3 using JIGSSAW.
 # Description
 Mesh generation script capable of creating unstructured meshes for WW3 global modeling. The tool leverages JIGSAWPY (https://github.com/dengwirda/jigsaw-python) for efficient triangulation.
 Main changes include:
-Implementation of the ocn_ww3.py to create uniform unstructured mesh for global WW3 model.
+Implementation of the ocn_ww3.py to create uniform and variable unstructured mesh for global WW3 model.
 This tool is under active development, with future work focused on variable unstructured mesh generation.
 
 # Installation
@@ -33,19 +33,20 @@ This tool is under active development, with future work focused on variable unst
  
 # Usage
 ## 5- run the script inside of WW3-tools/unst_msh_gen:
-- $python3 ocn_ww3.py --black_sea [option]
-		
-		option=  3: default which will have the Black Sea and the connections.
-			 2: will have the Balck sea as a seperate basin.
-			 1: will exclude the Black sea
 
-NOTE: the output will be gmsh format which will be used by WW3.
+## modify config.init
+- Specify the DEM netcdf file using the 'dem_file' in "DataFiles" section.
+- For uniform resolution 'hmax' = 'hmin' = 'hshr' = 'hfun_max' and 'nwave' = 0 in "Spacing" section.
+- To include or exclude Black-Sea change 'black_sea' in "CommandLineArg" section to:
+- 	                  3: will have the Black Sea and the connections.
+-                         2: will have the Balck sea as a seperate basin.
+-                         1: will exclude the Black sea
+-
+- you can specify the mesh name (jigsaw format or ww3 format) using 'mesh_file' and 'ww3_mesh_file'in "MeshSetting" section 
 
-NOTE: for different resolution (uniform) in km, you should change the following:
-- opts.hfun_hmax
-- hmax
-- hshr
-- hmin
+- $python3 ocn_ww3.py
+
+NOTE: the output will be gmsh format which will be used by WW3 (specified by 'ww3_mesh_file')
 
 NOTE: The output mesh will have -180:180 longitude, you can convert this by unisg ShiftMesh.py script, to 0:360 longitude.
 	input_file_path: your jigsaw mesh in gmsh format with -18:180 long
@@ -53,15 +54,23 @@ NOTE: The output mesh will have -180:180 longitude, you can convert this by unis
 
 
 ## 6- Using variable mode:
-- To create a mesh with finer resolution near the US coastlines you can define different region in json format (east coast, west coast and golf od Mexico, Purto Rico, and Hawaii):
+
+## modify config.ini
+- To create a mesh with finer resolution near the US coastlines you can define different region in json format (east coast, west coast and golf od Mexico, Purto Rico, and Hawaii); use the 'window_file' in the "DataFiles" section to specify the windows or parse the windows as;
 
 - $python3 window_mask.py --windows '[{"min_lon": -98, "max_lon": -64, "min_lat": 24, "max_lat": 44.5, "hshr": 5}, {"min_lon": -158, "max_lon": -155, "min_lat": 19, "max_lat": 22, "hshr": 5}, {"min_lon": -128, "max_lon": -64, "min_lat": 34.5, "max_lat": 48.5, "hshr": 5}, {"min_lon": -67.4, "max_lon": -64.1, "min_lat": 17.2, "max_lat": 18.3, "hshr": 5}]'
 
 NOTE: hshr is the shoreline resolution which can be smaller than the hmin which is defined globally.
 
-NOTE: You can define different background mesh based on lat location in the window_mask.py:
+- window_mask.py can read shapefiles in json format as well and assign user defined resolution (scale) to each polygon; use the 'shape_file' in the "DataFiles" to specify the shapefiles or parse the shapefiles as;
+
+- $python3 window_mask.py --shapefiles '[{"path": "./Shapefiles/Arctic.shp", "scale": 10}, {"path": "./Shapefiles/Gulf.shp", "scale": 5}, {"path": "./Shapefiles/Hawaii.shp", "scale": 5}, {"path": "./Shapefiles/PurtoRico.shp", "scale": 10}, {"path": "./Shapefiles/WestCoast.shp", "scale": 5}]'
+
+NOTE: You can create multiple shapefiles using QGIS or ArcGIS and save them in ./Shapefiles directory and assign different resolution (scale) to each polygone.
+
+NOTE: You can define different background mesh based on lat location in the window_mask.py via config.init
 		
-NOTE: for the background mesh you can define different resolution (for eaxmple, the globe is divided to three regions based on latitude and corresponding resolutions: 
+NOTE: for the background mesh you can define different resolution (for eaxmple, the globe is divided to three regions based on latitude and corresponding resolutions) in "Scalingsettings" of the config.ini as;
 
 - upper_bound = 50          # Lattitude that starts the upper section (ie lat > upper_bound) 
 - middle_bound = -20        # Determines the boundary between the upper  and middle sections.  The middle section is for upper_bound > lat > middle_bound
@@ -73,13 +82,18 @@ NOTE: for the background mesh you can define different resolution (for eaxmple, 
 - scale_south_upper = 30    # km resolution for upper south/lower section 
 - scale_south_lower = 9     # km mesh resolution at lower south/lower section 
 	
-NOTE: The output will be wmask.nc file which will have the mesh spacing info.
+NOTE: The output will be "wmask.nc" file which will have the mesh spacing info.
 
 
-NOTE:To create the variable mesh based on specified mesh spacing file in "wmask.nc" you can use the following comand:
+NOTE:To create the variable mesh based on mesh spacing file "wmask.nc", in the config.ini change the mask_file = wmask.nc
 
-- $python3 ocn_ww3.py --black_sea [option] --mask_file="wmask.nc"
+- $python3 ocn_ww3.py
 
+
+## 7- Plotting the mesh info:
+
+- to plot the elements, mesh size, and bathymetry data, use plot_msh.py and change the 'filename' to ww3 format mesh.
+- $python3 plot_msh.py
 
 ## Contributing
-This is ongoing effort with the great help of Darren Engwirda, JIGSAW developer.
+This is ongoing effort by Ali Salimi-Tarazouj with the great help of Darren Engwirda, JIGSAW developer.

--- a/unst_msh_gen/README.md
+++ b/unst_msh_gen/README.md
@@ -38,9 +38,9 @@ This tool is under active development, with future work focused on variable unst
 - Specify the DEM netcdf file using the 'dem_file' in "DataFiles" section.
 - For uniform resolution 'hmax' = 'hmin' = 'hshr' = 'hfun_max' and 'nwave' = 0 in "Spacing" section.
 - To include or exclude Black-Sea change 'black_sea' in "CommandLineArg" section to:
-- 	                  3: will have the Black Sea and the connections.
--                         2: will have the Balck sea as a seperate basin.
--                         1: will exclude the Black sea
+- 3 will have the Black Sea and the connections.
+- 2 will have the Balck sea as a seperate basin.
+- 1 will exclude the Black sea
 -
 - you can specify the mesh name (jigsaw format or ww3 format) using 'mesh_file' and 'ww3_mesh_file'in "MeshSetting" section 
 
@@ -56,15 +56,11 @@ NOTE: The output mesh will have -180:180 longitude, you can convert this by unis
 ## 6- Using variable mode:
 
 ## modify config.ini
-- To create a mesh with finer resolution near the US coastlines you can define different region in json format (east coast, west coast and golf od Mexico, Purto Rico, and Hawaii); use the 'window_file' in the "DataFiles" section to specify the windows or parse the windows as;
-
-- $python3 window_mask.py --windows '[{"min_lon": -98, "max_lon": -64, "min_lat": 24, "max_lat": 44.5, "hshr": 5}, {"min_lon": -158, "max_lon": -155, "min_lat": 19, "max_lat": 22, "hshr": 5}, {"min_lon": -128, "max_lon": -64, "min_lat": 34.5, "max_lat": 48.5, "hshr": 5}, {"min_lon": -67.4, "max_lon": -64.1, "min_lat": 17.2, "max_lat": 18.3, "hshr": 5}]'
+- To create a mesh with finer resolution near the US coastlines you can define different region in json format (east coast, west coast and golf od Mexico, Purto Rico, and Hawaii); use the 'window_file' in the "DataFiles" section to specify the windows.
 
 NOTE: hshr is the shoreline resolution which can be smaller than the hmin which is defined globally.
 
-- window_mask.py can read shapefiles in json format as well and assign user defined resolution (scale) to each polygon; use the 'shape_file' in the "DataFiles" to specify the shapefiles or parse the shapefiles as;
-
-- $python3 window_mask.py --shapefiles '[{"path": "./Shapefiles/Arctic.shp", "scale": 10}, {"path": "./Shapefiles/Gulf.shp", "scale": 5}, {"path": "./Shapefiles/Hawaii.shp", "scale": 5}, {"path": "./Shapefiles/PurtoRico.shp", "scale": 10}, {"path": "./Shapefiles/WestCoast.shp", "scale": 5}]'
+- window_mask.py can read shapefiles in json format as well and assign user defined resolution (scale) to each polygon; use the 'shape_file' in the "DataFiles" to specify the shapefiles.
 
 NOTE: You can create multiple shapefiles using QGIS or ArcGIS and save them in ./Shapefiles directory and assign different resolution (scale) to each polygone.
 

--- a/unst_msh_gen/README.md
+++ b/unst_msh_gen/README.md
@@ -34,17 +34,16 @@ This tool is under active development, with future work focused on variable unst
 # Usage
 ## 5- run the script inside of WW3-tools/unst_msh_gen:
 
-## modify config.init
+- modify config.init:
 - Specify the DEM netcdf file using the 'dem_file' in "DataFiles" section.
 - For uniform resolution 'hmax' = 'hmin' = 'hshr' = 'hfun_max' and 'nwave' = 0 in "Spacing" section.
 - To include or exclude Black-Sea change 'black_sea' in "CommandLineArg" section to:
-- 3 will have the Black Sea and the connections.
-- 2 will have the Balck sea as a seperate basin.
-- 1 will exclude the Black sea
--
+- 	3 will have the Black Sea and the connections.
+- 	2 will have the Balck sea as a seperate basin.
+- 	1 will exclude the Black sea
 - you can specify the mesh name (jigsaw format or ww3 format) using 'mesh_file' and 'ww3_mesh_file'in "MeshSetting" section 
 
-- $python3 ocn_ww3.py
+- $python3 ocn_ww3.py --config config.ini
 
 NOTE: the output will be gmsh format which will be used by WW3 (specified by 'ww3_mesh_file')
 
@@ -55,7 +54,7 @@ NOTE: The output mesh will have -180:180 longitude, you can convert this by unis
 
 ## 6- Using variable mode:
 
-## modify config.ini
+- modify config.ini
 - To create a mesh with finer resolution near the US coastlines you can define different region in json format (east coast, west coast and golf od Mexico, Purto Rico, and Hawaii); use the 'window_file' in the "DataFiles" section to specify the windows.
 
 NOTE: hshr is the shoreline resolution which can be smaller than the hmin which is defined globally.
@@ -77,13 +76,15 @@ NOTE: for the background mesh you can define different resolution (for eaxmple, 
 - #Mesh resolution of the lower section is linear from scale_south_upper to scale_south_upper
 - scale_south_upper = 30    # km resolution for upper south/lower section 
 - scale_south_lower = 9     # km mesh resolution at lower south/lower section 
+
+- $python3 window_mask.py --config config.ini
 	
 NOTE: The output will be "wmask.nc" file which will have the mesh spacing info.
 
 
 NOTE:To create the variable mesh based on mesh spacing file "wmask.nc", in the config.ini change the mask_file = wmask.nc
 
-- $python3 ocn_ww3.py
+- $python3 ocn_ww3.py --config config.ini
 
 
 ## 7- Plotting the mesh info:

--- a/unst_msh_gen/ShiftMesh.py
+++ b/unst_msh_gen/ShiftMesh.py
@@ -1,3 +1,13 @@
+"""
+To shift the mesh from -180:180 (lon) to 0:360
+
+input_file_path: -180:180 (lon) mesh in GMSH fomrat
+output_fil_pat: 0:360 (lon) mesh in GMSH format 
+"""
+
+# Author: Ali Salimi-Tarazouj
+
+
 input_file_path = './9km_nobc.ww3'
 output_file_path = './modified_9km_nobc.ww3'
 

--- a/unst_msh_gen/config.ini
+++ b/unst_msh_gen/config.ini
@@ -1,0 +1,56 @@
+; Spacing configurations for the mesh generation
+[Spacing]
+hmax = 100.0 
+; Maximum spacing in kilometers
+hshr = 100 
+; Spacing at the shoreline in kilometers
+nwav = 400 
+; Number of cells per square root of (gravity * water depth)
+hmin = 100.0 
+; Minimum spacing in kilometers
+dhdx = 0.05 
+; Maximum allowable gradient in spacing
+
+; Scaling settings based on latitude for mesh refinement
+[ScalingSettings]
+upper_bound = 50 
+; Northern latitude above which scale_north is applied
+middle_bound = -20 
+; Middle latitude boundary
+lower_bound = -90 
+; Southern latitude below which scale_south_lower is applied
+scale_north = 9 
+; Scaling factor for northern region
+scale_middle = 20 
+; Scaling factor for middle region
+scale_south_upper = 30 
+; Upper scaling factor for southern region
+scale_south_lower = 9 
+; Lower scaling factor as it approaches the lower bound
+
+; Mesh generation settings
+[MeshSettings]
+hfun_hmax = 100 
+; Global maximum mesh resolution, similar to hmax
+mesh_file = uglo_poly_nBlkS.msh 
+; Filename for the generated mesh in Jigsaw format
+ww3_mesh_file = uglo_poly_nBlkS.ww3 
+; Filename for the mesh in WW3 format
+
+; Command-line arguments and their default values
+[CommandLineArgs]
+black_sea = 3 
+; Black Sea configuration mode: 1=no Black Sea, 2=detached, 3=connected
+mask_file = wmask.nc 
+; Path to the weighting mask file, if any
+
+; Bathymetry and Regional data
+[DataFiles]
+dem_file = /scratch2/NCEPDEV/marine/alisalimi/jigsaw-geo-tutorial/VAR_MSH/CODE/RTopo_2_0_4_GEBCO_v2023_60sec_pixel.nc
+; DEM file
+
+shape_file = [{"path": "/scratch1/NCEPDEV/stmp2/Ali.Salimi/msh-gen/unst_msh_gen/VAR-MESH/Shapefiles/Arctic.shp", "scale": 10}, {"path": "/scratch1/NCEPDEV/stmp2/Ali.Salimi/msh-gen/unst_msh_gen/VAR-MESH/Shapefiles/Gulf.shp", "scale": 5}, {"path": "/scratch1/NCEPDEV/stmp2/Ali.Salimi/msh-gen/unst_msh_gen/VAR-MESH/Shapefiles/Hawaii.shp", "scale": 5}, {"path": "/scratch1/NCEPDEV/stmp2/Ali.Salimi/msh-gen/unst_msh_gen/VAR-MESH/Shapefiles/PurtoRico.shp", "scale": 10}, {"path": "/scratch1/NCEPDEV/stmp2/Ali.Salimi/msh-gen/unst_msh_gen/VAR-MESH/Shapefiles/WestCoast.shp", "scale": 5}]
+; shapefiles for regional mesh tefinement
+
+;window_file = [{"min_lon": -98, "max_lon": -64, "min_lat": 24, "max_lat": 44.5, "hshr": 5}, {"min_lon": -158, "max_lon": -155, "min_lat": 19, "max_lat": 22, "hshr": 5}, {"min_lon": -128, "max_lon": -64, "min_lat": 34.5, "max_lat": 48.5, "hshr": 5}, {"min_lon": -67.4, "max_lon": -64.1, "min_lat": 17.2, "max_lat": 18.3, "hshr": 5}]
+; user-defined windows to refine the mesh regionally.

--- a/unst_msh_gen/ocn_ww3.py
+++ b/unst_msh_gen/ocn_ww3.py
@@ -561,7 +561,7 @@ if (__name__ == "__main__"):
     point = jigsawpy.R3toS2(geom.radii, point)  # to [lon,lat] in deg
     point*= 180. / np.pi
     depth = np.reshape(-1*mesh.value, (mesh.value.size, 1))
-    depth[depth <= -2] = 50
+    depth[depth <= 0] = 2
     point = np.hstack((point, depth))  # append elev. as 3rd coord.
     cells = [("triangle", mesh.tria3["index"])]
     tri_data=cells[0][1]+1

--- a/unst_msh_gen/ocn_ww3.py
+++ b/unst_msh_gen/ocn_ww3.py
@@ -20,27 +20,31 @@ from scipy.sparse.csgraph import connected_components
 
 from spacing import *
 
-# Load the configuration file
-config = configparser.ConfigParser()
-config.read('config.ini')
+def parse_input_args():
+    parser = argparse.ArgumentParser(description='Create a mask file with multiple methods.')
+    parser.add_argument('--config', type=str, required=True, help='Path to the configuration file.')
+    args = parser.parse_args()
+    return args
 
-# Create the parser
-parser = argparse.ArgumentParser(description="Run mesh gen with specific region settings.")
+def load_configuration(config_path):
+    config = configparser.ConfigParser()
+    config.read(config_path)
 
-# Command-line arguments with defaults from config file
-parser.add_argument('--black_sea', type=int, default=config.getint('CommandLineArgs', 'black_sea'),
-                    help='Set the region mode: 1 no black-sea, 2 black-sea detached, 3 black-sea with connections. Default is 3.')
-
-parser.add_argument('--mask_file', type=str, default=config.get('CommandLineArgs', 'mask_file', fallback=''),
-                    help='Path to the mask file, if any. Leave empty if not used.')
-
-
-# Parse the command-line arguments
-args = parser.parse_args()
-
-# Use args.black_sea to access the black_sea value
-
-
+        # Creating a dictionary and populating it with configuration settings
+    configurations = {
+        'mesh_file': config.get('MeshSettings', 'mesh_file', fallback=''),
+        'ww3_mesh_file':config.get('MeshSettings', 'WW3_mesh_file', fallback=''),
+        'hfun_hmax': float(config.get('MeshSettings', 'hfun_hmax', fallback='100')),
+        'black_sea': config.getint('CommandLineArgs', 'black_sea', fallback=3),
+        'mask_file': config.get('CommandLineArgs', 'mask_file', fallback=''),
+        'hmax': float(config.get('Spacing', 'hmax', fallback='100.0')),
+        'hshr': float(config.get('Spacing', 'hshr', fallback='100')),
+        'nwav': int(config.get('Spacing', 'nwav', fallback='400')),
+        'hmin': float(config.get('Spacing', 'hmin', fallback='100.0')),
+        'dhdx': float(config.get('Spacing', 'dhdx', fallback='0.05')),
+        'dem_file': config.get('DataFiles', 'dem_file', fallback='')
+    }
+    return configurations
 
 ISOLATED = 30000.  # min surface area [km^2]
 
@@ -53,6 +57,9 @@ opts = jigsawpy.jigsaw_jig_t()
 def create_msh():
 
 #-- create a simple uniform mesh for the globe
+    
+    args = parse_input_args()
+    configurations = load_configuration(args.config)
 
     print("*create-msh...")
 
@@ -73,10 +80,10 @@ def create_msh():
     # solve |dh/dx| constraints in spacing
     jigsawpy.cmd.marche(opts, spac)
     
-    opts.mesh_file = config['MeshSettings']['mesh_file']  #jigsaw format mesh file
+    opts.mesh_file = configurations['mesh_file']  #jigsaw format mesh file
     
     opts.hfun_scal = "absolute"
-    opts.hfun_hmax = float(config['MeshSettings']['hfun_hmax'])           # global maximum mesh resolution (similar to hmax)
+    opts.hfun_hmax = configurations['hfun_hmax']           # global maximum mesh resolution (similar to hmax)
     opts.mesh_dims = +2             # 2-dim. simplexes
     opts.optm_iter = +64            # number of itereation for the optimization
     opts.optm_cost = "skew-cos"
@@ -86,16 +93,19 @@ def create_msh():
     
 def create_siz():
 
+    args = parse_input_args()
+    configurations = load_configuration(args.config)
+
     #-- create mesh spacing function for the globe: for uniform mesh hmax = hshr = hmin
 
-    hmax = float(config['Spacing']['hmax']) # maximum spacing [km] 
-    hshr = float(config['Spacing']['hshr'])  # shoreline spacing
-    nwav = int(config['Spacing']['nwav'])  # number of cells per sqrt(g*H)
-    hmin = float(config['Spacing']['hmin'])  # minimum spacing
-    dhdx = float(config['Spacing']['dhdx'])  # allowable spacing gradient: for more gradual transition use lower value
-
+    hmax = configurations['hmax'] # maximum spacing [km] 
+    hshr = configurations['hshr']   # shoreline spacing
+    nwav = configurations['nwav']   # number of cells per sqrt(g*H)
+    hmin = configurations['hmin']  # minimum spacing
+    dhdx = configurations['dhdx']  # allowable spacing gradient: for more gradual transition use lower value
+    mask_file = configurations['mask_file'] #user defined scaling file
     # Load the DEM file from the config
-    dem_file = config['DataFiles']['dem_file']
+    dem_file = configurations['dem_file']
 
     data = nc.Dataset(dem_file,"r")
 
@@ -127,8 +137,9 @@ def create_siz():
    
 #-- apply user-defined scaling: multiply h(x) by mask array
 
-    if hasattr(args, 'mask_file') and args.mask_file:
-       hmat = scale_spacing_via_mask(args, hmat)
+    if mask_file:
+        hmat = scale_spacing_via_mask(args, hmat)
+        print("Scaling applied using mask_file:", mask_file)
     else:
     # Handle case where mask_file is not provided
         print("No mask file provided. Proceeding without scaling...")
@@ -179,12 +190,15 @@ def create_siz():
 
 def inject_dem():
 
+    args = parse_input_args()
+    configurations = load_configuration(args.config)
+
 #-- remap a DEM on to the vertices of the mesh
 
     print("*inject-dem...")
 
         # Load the DEM file from the config
-    dem_file = config['DataFiles']['dem_file']
+    dem_file = configurations['dem_file']
 
     data = nc.Dataset(dem_file,"r")
 
@@ -337,7 +351,10 @@ def filter_wet(mesh, mask):
     return mask
 
 
-def filter_ocn(black_sea=args.black_sea):
+def filter_ocn():
+
+    args = parse_input_args()
+    configurations = load_configuration(args.config)
 
 #-- use the remapped elev. to keep ocean cells
 
@@ -428,6 +445,7 @@ def filter_ocn(black_sea=args.black_sea):
         mesh.smids[:, 0] <= blacksea_lon_max
     ))
     
+    black_sea = configurations['black_sea']
         # Activate regions based on black_sea option
     if black_sea == 1:  # Caspian and Black Sea
         surf[caspian_region] = -9999.0
@@ -525,6 +543,9 @@ def write_gmsh_mesh(filename, node_data, tri):
 
 if (__name__ == "__main__"):
 
+    args = parse_input_args()
+    configurations = load_configuration(args.config)
+
     create_msh()
     inject_dem()
     filter_ocn()
@@ -536,10 +557,9 @@ if (__name__ == "__main__"):
     point = jigsawpy.R3toS2(geom.radii, point)  # to [lon,lat] in deg
     point*= 180. / np.pi
     depth = np.reshape(-1*mesh.value, (mesh.value.size, 1))
-    depth[depth <= 0] = 50
+    depth[depth <= -2] = 50
     point = np.hstack((point, depth))  # append elev. as 3rd coord.
     cells = [("triangle", mesh.tria3["index"])]
     tri_data=cells[0][1]+1
-    ww3_mesh_file = config['MeshSettings']['ww3_mesh_file']
+    ww3_mesh_file = configurations['ww3_mesh_file']
     write_gmsh_mesh(ww3_mesh_file, point, tri_data)
-   

--- a/unst_msh_gen/ocn_ww3.py
+++ b/unst_msh_gen/ocn_ww3.py
@@ -170,8 +170,12 @@ def create_siz():
 
     ymid = 41.5 * np.pi / 180.
     xmid = 30.5 * np.pi / 180.
-        
-    spac.value = hmat 
+
+    zoom = +100.0 - 99.0 * np.exp(-(
+        6.75 * (xmat - xmid) ** 2 +
+        12.5 * (ymat - ymid) ** 2) ** 2)
+    
+    spac.value = hmat*zoom 
     spac.slope = np.array(dhdx)
     spac.value = np.minimum(hmax, spac.value)
     

--- a/unst_msh_gen/plot_msh.py
+++ b/unst_msh_gen/plot_msh.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Apr 19 15:17:57 2024
+
+@author: Ali.Salimi-Tarazouj
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.tri as tri
+import matplotlib.ticker as mticker
+import cartopy
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+import argparse
+
+
+def read_gmsh(filename):
+    with open(filename, 'r') as f:
+        # Skip mesh format lines
+        for _ in range(4):  # Skip 4 lines directly (including $Nodes)
+            next(f)
+        
+        # Read number of nodes
+        nn = int(next(f).strip())
+        
+        # Initialize node coordinate and depth arrays
+        xy = np.zeros((nn, 2), dtype=np.double)
+        depth = np.zeros(nn, dtype=np.double)
+        
+        # Read coordinates and depths
+        for i in range(nn):
+            line = next(f).split()
+            idx = int(line[0]) - 1
+            x_coord = float(line[1])
+            xy[idx, 0] = x_coord - 360 if x_coord > 180 else x_coord
+            xy[idx, 1] = float(line[2])
+            depth[idx] = float(line[3])
+        
+        # Skip '$EndNodes' and '$Elements'
+        next(f)
+        next(f)
+        
+        # Read number of elements
+        ne = int(next(f).strip())
+        
+        # Initialize temporary arrays to read in element info
+        ecttemp = np.zeros((ne, 3), dtype=np.int32)
+        bndtemp = []
+        
+        elem_count = 0
+        for _ in range(ne):
+            line = next(f).split()
+            eltype = int(line[1])
+            if eltype == 15:
+                bndtemp.append(int(line[5]) - 1)
+            else:
+                ecttemp[elem_count, :] = [int(line[6]) - 1, int(line[7]) - 1, int(line[8]) - 1]
+                elem_count += 1
+        
+        # Trim the ect array to the actual number of elements
+        ect = ecttemp[:elem_count, :]
+        bnd = np.array(bndtemp, dtype=np.int32)
+    
+    return xy, depth, ect, bnd
+
+def calc_elm_size(xy, ect):
+    nn = len(xy)
+    ne = len(ect)
+    radiusofearth = 6378.137  # radius of earth at equator
+    d2r = np.pi / 180  # degrees to radians conversion factor
+
+    # Initialize arrays to store min and max distances
+    distmin = np.full(nn, np.inf)
+    distmax = np.zeros(nn)
+
+    # Precompute cosines and sines for latitudes
+    cos_lat = np.cos(xy[:, 1] * d2r)
+    sin_lat = np.sin(xy[:, 1] * d2r)
+
+    # Calculate distances for all elements
+    for i, j, k in ect:
+        # Extract coordinates
+        lon_i, lon_j, lon_k = xy[i, 0], xy[j, 0], xy[k, 0]
+        cos_lat_i, cos_lat_j, cos_lat_k = cos_lat[i], cos_lat[j], cos_lat[k]
+        sin_lat_i, sin_lat_j, sin_lat_k = sin_lat[i], sin_lat[j], sin_lat[k]
+
+        # Calculate distances using the Haversine formula
+        dist_ij = 2 * radiusofearth * np.arcsin(np.sqrt(np.sin((xy[j, 1] - xy[i, 1]) * d2r / 2) ** 2 +
+                                                       cos_lat_i * cos_lat_j * np.sin((lon_j - lon_i) * d2r / 2) ** 2))
+        dist_jk = 2 * radiusofearth * np.arcsin(np.sqrt(np.sin((xy[k, 1] - xy[j, 1]) * d2r / 2) ** 2 +
+                                                       cos_lat_j * cos_lat_k * np.sin((lon_k - lon_j) * d2r / 2) ** 2))
+        dist_ki = 2 * radiusofearth * np.arcsin(np.sqrt(np.sin((xy[i, 1] - xy[k, 1]) * d2r / 2) ** 2 +
+                                                       cos_lat_k * cos_lat_i * np.sin((lon_i - lon_k) * d2r / 2) ** 2))
+
+        # Update min and max distances for each node
+        distmin[i], distmax[i] = min(distmin[i], dist_ij, dist_ki), max(distmax[i], dist_ij, dist_ki)
+        distmin[j], distmax[j] = min(distmin[j], dist_ij, dist_jk), max(distmax[j], dist_ij, dist_jk)
+        distmin[k], distmax[k] = min(distmin[k], dist_jk, dist_ki), max(distmax[k], dist_jk, dist_ki)
+
+    return distmin, distmax
+
+def create_mask(xy, ect):
+    # Extract x-coordinates of the nodes for each element
+    x_coords = xy[ect, 0]  # ect indexes rows in xy, column 0 is x-coordinates
+
+    # Check for cross-dateline elements
+    # Calculate signs and check if all are the same for each element
+    signs = np.sign(x_coords)
+    uniform_sign = (np.ptp(signs, axis=1) == 0)  # Change in peak-to-peak (max-min) across rows; if 0, all signs are the same
+
+    # Check for elements near the dateline, i.e., abs(x) < 10
+    near_dateline = (np.abs(x_coords) < 10).any(axis=1)  # Check any coordinate < 10 in absolute value for each element
+
+    # Combine conditions: elements are valid if they do not cross the dateline and are not near the dateline
+    mask = ~(uniform_sign | near_dateline)
+
+    return mask.astype(int)  # Convert boolean mask to integer (1s and 0s)
+
+
+
+def setup_plot(ax, extent=[-180, 180, -90, 90]):
+    """ Common plot setup function """
+    ax.set_extent(extent, crs=ccrs.PlateCarree())
+    ax.add_feature(cfeature.COASTLINE, zorder=101)
+    gl = ax.gridlines(crs=ccrs.PlateCarree(), draw_labels=True, linewidth=2, color='gray', alpha=0.5, linestyle='--')
+    gl.top_labels = False
+    gl.right_labels = False
+    gl.xlines = False
+    gl.ylines = False
+    gl.xlocator = mticker.FixedLocator(np.linspace(extent[0], extent[1], 7))
+    gl.ylocator = mticker.FixedLocator(np.linspace(extent[2], extent[3], 7))
+    gl.xformatter = LongitudeFormatter()
+    gl.yformatter = LatitudeFormatter()
+
+def plot_eleminfo(plotdescriptor, xy, ect, distmin, distmax, depth, highlight_nodes=None):
+    print('Grid')
+    print(plotdescriptor)
+    print('Min/max of distmin:', np.min(distmin), np.max(distmin))
+    print('Min/max of distmax:', np.min(distmax), np.max(distmax))
+    print('Min/max of bathy:', np.min(depth), np.max(depth))
+
+    mask = create_mask(xy,ect)
+  
+  #create one tringulation and use it for multiple plots: 
+    triang=tri.Triangulation(xy[:,0],xy[:,1],triangles=ect, mask=mask)
+    vpltmin=1
+    vpltmax= 30
+        
+
+    # Shared figure setup
+    figsize = [18.0, 9.0]
+    plots = [
+        ('elm', 'k-', 'Element outlines', None, 'jet'),
+        ('maxsize', distmax, 'Element size in km', 'gouraud', 'jet'),
+        ('minsize', distmin, 'Element size in km', 'gouraud', 'jet'),
+        ('bathy', depth, 'Bathymetry in m', None, 'jet')
+    ]
+
+    for suffix, data, label, shading, cmap in plots:
+        fig = plt.figure(figsize=figsize)
+        ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
+        setup_plot(ax)
+        if suffix == 'elm':
+            cf = ax.triplot(triang, 'k-', linewidth=0.5)
+        else:
+            cf = ax.tripcolor(triang, data, cmap=cmap, shading=shading if shading else 'flat', vmin=vpltmin, vmax=vpltmax if data is not depth else None)
+            plt.colorbar(mappable=cf, label=label)
+
+        if highlight_nodes is not None and suffix == 'elm':
+            ax.scatter(xy[highlight_nodes, 0], xy[highlight_nodes, 1], color='red', s=100, zorder=102, transform=ccrs.PlateCarree())
+
+        plt.savefig(f'{suffix}_{plotdescriptor}.png')
+        #plt.close()
+
+filename = "./uglo_poly_nBlkS.ww3"
+
+descriptor = "uglo_poly_nBlkS"
+
+xy, depth, ect, bnd =  read_gmsh(filename)
+
+distmin, distmax = calc_elm_size(xy, ect)
+highlighted_nodes = []  # Replace with your actual node indices , 12776, 13923
+plot_eleminfo(descriptor, xy, ect, distmin, distmax, depth, highlight_nodes=highlighted_nodes)

--- a/unst_msh_gen/plot_msh.py
+++ b/unst_msh_gen/plot_msh.py
@@ -20,6 +20,20 @@ import argparse
 
 
 def read_gmsh(filename):
+    #purpose: this function reads a gmsh file and returns node and element information
+    # additional information about the gmsh file format can be found
+    # in many places including here: http://gmsh.info/dev/doc/texinfo/gmsh.pdf
+    # The gmsh format is what the WW3 model uses to define unstructured grids
+
+    #input:
+    # filename - name of gmsh file
+
+    #output:
+    #xy    -  x/y or lon/lat of nodes
+    #depth - depth value at node points
+    #ect   - element connection table
+    #bnd   - list of boundary nodes
+
     with open(filename, 'r') as f:
         # Skip mesh format lines
         for _ in range(4):  # Skip 4 lines directly (including $Nodes)
@@ -69,6 +83,18 @@ def read_gmsh(filename):
     return xy, depth, ect, bnd
 
 def calc_elm_size(xy, ect):
+
+    #purpose: Calculate element size, by calculating the distance between each node on the triangle, then
+   # saving the minimum or maximum distance for each node
+
+   #input:
+   # xy  -  x/y or lon/lat of nodes
+   # ect - element connection table
+
+   #output:
+   # distmin(number of nodes)  - the minimum distance between this node and any connected node point
+   # distmax(number of nodes)  - the maximum distance between this node and any connected node point
+
     nn = len(xy)
     ne = len(ect)
     radiusofearth = 6378.137  # radius of earth at equator

--- a/unst_msh_gen/plot_msh.py
+++ b/unst_msh_gen/plot_msh.py
@@ -3,7 +3,9 @@
 """
 Created on Fri Apr 19 15:17:57 2024
 
-@author: Ali.Salimi-Tarazouj
+@author: Ali Salimi-Tarazouj
+
+This script originally was developed by Steven Brus (@sbrus89) and revised by Ali Salimi-Tarazouj to work efficiently for very high resolution meshes
 """
 
 import numpy as np

--- a/unst_msh_gen/spacing.py
+++ b/unst_msh_gen/spacing.py
@@ -2,7 +2,7 @@
 """ Mesh spacing utilities, for barotropic flows
 """
 
-# Authors: Darren Engwirda, Ali Salimi
+# Authors: Darren Engwirda, Ali Salimi-Tarazouj
 
 # routines to compute mesh spacing functions that scale
 # with shallow-water wave lengths, elev. gradients, etc 

--- a/unst_msh_gen/window_mask.py
+++ b/unst_msh_gen/window_mask.py
@@ -1,84 +1,145 @@
 """ Jigsaw meshes for WW3 with global bathymetry
 """
 
-# Authors: Ali Salimi, Darren
+# Authors: Ali Salimi-Tarazouj
 
-# This script will create mesh spacing based on user defined windows in json format.
+# This script will create mesh spacing based on user defined windows in json format or based on polygons in shapefile format
 
+import configparser
 import numpy as np
 import netCDF4 as nc
 import argparse
 import json
+import geopandas as gpd
+from shapely.geometry import Point
 
-def create_mask_file(windows):
-    # Open the data file
-    data = nc.Dataset("RTopo_2_0_4_GEBCO_v2023_60sec_pixel.nc", "r")
+# Load the configuration file
+config = configparser.ConfigParser()
+config.read('config.ini')
 
-    # Extract longitude and latitude arrays
+def create_mask_file(data_filename, output_filename, windows=None, shapefiles=None, default_scale=20):
+    # Load DEM data
+    data = nc.Dataset(data_filename, "r")
     xlon = np.asarray(data["lon"][:])
     ylat = np.asarray(data["lat"][:])
     elev = np.asarray(data["bed_elevation"][:], dtype=np.float32) + np.asarray(data["ice_thickness"][:], dtype=np.float32)
 
     # Compute midpoints for longitude and latitude
-    xmid = 0.5 * (xlon[:-1] + xlon[+1:])
-    ymid = 0.5 * (ylat[:-1] + ylat[+1:])
-
-    # Create a meshgrid of midpoints
+    xmid = 0.5 * (xlon[:-1] + xlon[1:])
+    ymid = 0.5 * (ylat[:-1] + ylat[1:])
     xmat, ymat = np.meshgrid(xmid, ymid)
 
-    # Initialize scal with a default condition
-    #scal = np.where(ymat > 50, 9, np.where(ymat < -20, 30, 20))
+    # Scaling settings from the config file
+    upper_bound = float(config['ScalingSettings']['upper_bound'])
+    middle_bound = float(config['ScalingSettings']['middle_bound'])
+    lower_bound = float(config['ScalingSettings']['lower_bound'])
+    scale_north = float(config['ScalingSettings']['scale_north'])
+    scale_middle = float(config['ScalingSettings']['scale_middle'])
+    scale_south_upper = float(config['ScalingSettings']['scale_south_upper'])
+    scale_south_lower = float(config['ScalingSettings']['scale_south_lower'])
 
-    # Define the boundaries and scaling values: The globe is divided to three regions based on latitude and corresponding resolutions
-    upper_bound = 50       # Lattitude that starts the upper section (ie lat > upper_bound) 
-    middle_bound = -20     # Determines the boundary between the upper  and middle sections.  The middle section is for upper_bound > lat > middle_bound 
-    lower_bound = -90      # Boundary of lowest section, likely -90,   Lower section is:   middle_bound > lat > lower_bound
-    scale_north = 9        # mesh resolution  in km for upper section ( lat > upper_bound )
-    scale_middle = 20      # mesh resolution in km for  middle section for middle_bound < lat < upper_boun
-    # Mesh resolution of the lower section is linear from scale_south_upper to scale_south_upper
-    scale_south_upper = 30 # km resolution for upper south/lower section 
-    scale_south_lower = 9  # km mesh resolution at lower south/lower section 
+    # Apply scaling based on latitude bands
+    scal = np.where(ymat > upper_bound, scale_north,
+                    np.where(ymat > middle_bound, scale_middle,
+                             scale_south_upper + (scale_south_lower - scale_south_upper) *
+                             (ymat - middle_bound) / (lower_bound - middle_bound)))
 
-    # Calculate the scaling using conditions
-    scal = np.where(ymat > upper_bound,
-                    scale_north,  # Use 9 km for ymat > 50
-                    np.where(ymat > middle_bound,
-                             scale_middle,  # Use 20 km for -20 < ymat <= 50
-                             # Gradual decrease from 30 km to 9 km as latitude decreases from -20 to -90
-                             scale_south_upper + (scale_south_lower - scale_south_upper) * 
-                             (ymat - middle_bound) / (lower_bound - middle_bound)
-                            ))
+    # Apply window-based refinement if provided
+    if windows:
+        for window in windows:
+            window_mask_lon = np.logical_and(xmat >= window["min_lon"], xmat <= window["max_lon"])
+            window_mask_lat = np.logical_and(ymat >= window["min_lat"], ymat <= window["max_lat"])
+            window_mask = np.logical_and(window_mask_lon, window_mask_lat)
+            
+            mask_elevation = np.logical_and(elev >= -4., elev <= +8.)
+            mask_final = np.logical_and(mask_elevation, window_mask)
+            scal[mask_final] = window["hshr"]
 
-    # Process each window
-    for window in windows:
-        # Apply the 'hshr' value for the current window where conditions are met
-        window_mask_lon = np.logical_and(xmat >= window["min_lon"], xmat <= window["max_lon"])
-        window_mask_lat = np.logical_and(ymat >= window["min_lat"], ymat <= window["max_lat"])
-        window_mask = np.logical_and(window_mask_lon, window_mask_lat)
-        
-        mask_elevation = np.logical_and(elev >= -4., elev <= +8.)
-        mask_final = np.logical_and(mask_elevation, window_mask)
-        scal[mask_final] = window["hshr"]
+    # Process shapefiles if provided
+    if shapefiles:
+        for shapefile, scale in shapefiles:
+            gdf = gpd.read_file(shapefile)
+            minx, miny, maxx, maxy = gdf.total_bounds
+            # Subset the meshgrid
+            mask_x = (xmid >= minx) & (xmid <= maxx)
+            mask_y = (ymid >= miny) & (ymid <= maxy)
+            x_sub, y_sub = xmid[mask_x], ymid[mask_y]
+            xmat_sub, ymat_sub = np.meshgrid(x_sub, y_sub)
 
-    # Create a new NetCDF file to store the mask
-    data_out = nc.Dataset("wmask.nc", "w")
+            # Create GeoDataFrame for the points in the subset
+            points_sub = [Point(x, y) for x, y in zip(xmat_sub.flatten(), ymat_sub.flatten())]
+            points_gdf_sub = gpd.GeoDataFrame(geometry=points_sub)
+            points_gdf_sub.set_crs(gdf.crs, inplace=True)
+
+            # Spatial join only for the subset area
+            overlay_sub = gpd.sjoin(points_gdf_sub, gdf, how="left", op='intersects')
+            overlay_sub['scale'] = overlay_sub['index_right'].apply(lambda x: scale if x >= 0 else default_scale)
+            scales_sub = overlay_sub['scale'].to_numpy().reshape(xmat_sub.shape)
+
+            # Map the scales back to the original full matrix
+            x_indices = np.searchsorted(xmid, x_sub)
+            y_indices = np.searchsorted(ymid, y_sub)
+            scal[np.ix_(mask_y, mask_x)] = scales_sub
+
+    # Write results to a NetCDF file
+    data_out = nc.Dataset(output_filename, "w")
     data_out.createDimension("nlon", xmid.size)
     data_out.createDimension("nlat", ymid.size)
-    if "val" not in data_out.variables.keys():
-        data_out.createVariable("val", "f4", ("nlat", "nlon"))
-    data_out["val"][:, :] = scal
+    var = data_out.createVariable("val", "f4", ("nlat", "nlon"))
+    var[:, :] = scal
     data_out.close()
 
-def parse_windows_from_args():
-    parser = argparse.ArgumentParser(description='Create a mask file with multiple windows.')
-    parser.add_argument('--windows', type=str, required=True,
-                        help='JSON string with window definitions. Example: \'[{"min_lon": -130, "max_lon": -64, "min_lat": 24.5, "max_lat": 47.5, "hshr": 5}]\'')
-    
+def parse_input_args():
+    parser = argparse.ArgumentParser(description='Create a mask file with multiple methods.')
+    parser.add_argument('--windows', type=str, help='JSON string with window definitions.')
+    parser.add_argument('--shapefiles', type=str, help='JSON string with shapefile paths and scales.')
     args = parser.parse_args()
-    windows = json.loads(args.windows)
-    return windows
+
+    # Configuration setup
+    config = configparser.ConfigParser()
+    config.read('config.ini')
+
+    # Decide where to load windows from
+    if args.windows:
+        windows = json.loads(args.windows)
+    elif 'window_file' in config['DataFiles']:  # Make sure the 'window_file' key exists in 'DataFiles' section
+        windows = json.loads(config['DataFiles']['window_file'])
+    else:
+        windows = None  # Default to None if no command line input or config entr
+
+    # Decide where to load shapefiles from
+    if args.shapefiles:
+        shapefiles = json.loads(args.shapefiles)
+    elif 'shape_file' in config['DataFiles']:  # Ensure 'shape_file' key exists in 'DataFiles' section
+        shapefiles = json.loads(config['DataFiles']['shape_file'])
+    else:
+        shapefiles = None
+
+    if shapefiles:
+        shapefiles = [(shp['path'], shp['scale']) for shp in shapefiles]
+        print("Parsed Shapefiles:", shapefiles)  # Debugging print
+
+
+    #windows = json.loads(args.windows) if args.windows else None
+    #shapefiles = json.loads(args.shapefiles) if args.shapefiles else None
+
+    return windows, shapefiles
 
 if __name__ == "__main__":
-    windows = parse_windows_from_args()
-    create_mask_file(windows)
+    windows, shapefiles = parse_input_args()
+    """
+    # Fallback to hardcoded shapefiles if none provided via command line
+    if not shapefiles:
+        shapefiles = [
+            ("./Shapefiles/Arctic.shp", 10),
+            ("./Shapefiles/Gulf.shp", 5),
+            ("./Shapefiles/Hawaii.shp", 5),
+            ("./Shapefiles/PurtoRico.shp", 10),
+            ("./Shapefiles/WestCoast.shp", 5)
+        ]
+    """
+    # Load DEM file path from the config file
+    dem_file = config['DataFiles']['dem_file']
+
+    create_mask_file(dem_file, "wmask.nc", windows, shapefiles)
 


### PR DESCRIPTION
…, addressing issue #55

# Pull Request Summary
<!-- A short overview of the PR --> 
Adding the mesh refinement capability based on polygons and adding config.ini
## Description
<!--
The window_masking.py is changed to read the polygons in ESRI shapefile format and refine the mesh based on each resolution (scale). A user defined config.ini file is added to specify the DEM, mesh spacing, mask file, windows and shapefiles. 

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
-->

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3-tools/issues/<issue_number>
-->
issue #55 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Adding the polygons to for mesh refinement and config.ini file 
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
 
### Testing

* How were these changes tested?


