### PR TITLE
Adding the wind speed calculation for the model netcdf output in Prosat_interpolation.py 

### DIFF
--- a/ww3tools/ProcSat_interpolation.py
+++ b/ww3tools/ProcSat_interpolation.py
@@ -269,6 +269,18 @@ def interpolate_netcdf(model_data_directory, model_data_pattern, satellite_file,
     # Load and concatenate the model data files
     model_data_list = [xr.open_dataset(file) for file in model_data_files]
     model_data_combined = xr.concat(model_data_list, dim='time')
+    
+    # Calculate the wind speed if not in the model output
+    try:
+      WIND_surface = model_data_combined['WIND_surface']
+      print("WIND_surface found in dataset. Using existing variable.")
+    except KeyError:
+      print("WIND_surface not found. Computing wind speed from uwnd and vwnd.")
+      uwnd = model_data_combined['uwnd']
+      vwnd = model_data_combined['vwnd']
+      WIND_surface = np.sqrt(uwnd**2 + vwnd**2)
+      # Add or overwrite wind speed variable for interpolation
+      model_data_combined['WIND_surface'] = WIND_surface
     model_data_combined.close()  # Close the files after loading
 
     # Convert longitudes from -180 to 180 to 0 to 360, if necessary


### PR DESCRIPTION
…Prosat_interpolation.py script

# Pull Request Summary
<!-- A short overview of the PR --> 
Adding the wind speed calculation for the model netcdf output 
## Description
The model netcdf output does not store the wind speed variable, instead it stores uwnd and vwnd. Hence, the WIND_surface should be calculated for the ProcSat_interpolation.py


### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3-tools/issues/<issue_number>
-->
fixes issue #71 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Adding the wind speed calculation for the model netcdf output 
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
 
### Testing

* How were these changes tested?
The script is used to collocate the WW3 netcdf field output on HERA:
/scratch2/NCEPDEV/marine/alisalimi/HR4-OPT/FromJessica/tpo1/ICunstructuredRuns15km/RunShelDir/202002/interpolated
![CRYOSAT2_wnd_combinedPDF](https://github.com/user-attachments/assets/9b35fde0-0299-4efa-95d5-a8e867ce48dd)
![CRYOSAT2_wnd_combinedQQplot](https://github.com/user-attachments/assets/4a8b88e8-c572-40f8-b3f3-7f2c31b065dd)
![CRYOSAT2_wnd_combinedScatterPlot](https://github.com/user-attachments/assets/244b66f2-361a-48a5-9aeb-292554dc00f4)
![CRYOSAT2_wnd_combinedTaylorDiagram](https://github.com/user-attachments/assets/65715532-6c32-436f-8ab7-a9949e47b6d8)


