### PR TITLE
Add filter for Hs and WSP when processing pb2nc netCDF file

### DIFF
--- a/ush/pb2nc_to_ww3tools.py
+++ b/ush/pb2nc_to_ww3tools.py
@@ -29,7 +29,7 @@ from netCDF4 import Dataset, chartostring
 # =========================
 # USER-DEFINED SETTINGS
 # =========================
-WORKDIR = "/scratch3/NCEPDEV/marine/Ming.Chen/ursa/wind_eval"            # working directory contains WW3-tools
+WORKDIR = "/scratch3/NCEPDEV/marine/Ming.Chen/ursa/preBUFR_filter/"            # working directory contains WW3-tools
 
 SAT_NAME = "JASON3"
 HS_MNEM  = "KBSW"
@@ -62,48 +62,69 @@ for infile in infiles:
 
     with Dataset(infile, "r") as nc:
         # Read string tables
-        obs_var_list = [str(s).strip().strip("\x00") for s in chartostring(nc.variables["obs_var"][:])]
-        vld_table    = [str(s).strip().strip("\x00") for s in chartostring(nc.variables["hdr_vld_table"][:])]
+        obs_var_list = [str(s).strip().strip("\x00") for s in chartostring(nc.variables["obs_var"][:])]        # data name
+        vld_table    = [str(s).strip().strip("\x00") for s in chartostring(nc.variables["hdr_vld_table"][:])]  # timestamps
 
-        m2vid = {name.strip(): i for i, name in enumerate(obs_var_list) if name.strip()}
+        m2vid = {name.strip(): i for i, name in enumerate(obs_var_list) if name.strip()}                       # add indexes in data name
 
-        wsp_vid = m2vid.get(WSP_MNEM)
-        hs_vid  = m2vid.get(HS_MNEM)
+        wsp_vid = m2vid.get(WSP_MNEM)    # number represents WSP (wind speed)
+        hs_vid  = m2vid.get(HS_MNEM)     # number represents HS  (significant wave height)
 
         if wsp_vid is None:
             print(f"  Skip: missing {WSP_MNEM}")
             continue
 
         # Load core arrays
-        obs_val = nc.variables["obs_val"][:].astype(np.float32)
-        obs_vid = nc.variables["obs_vid"][:].astype(np.int64)
-        obs_hid = nc.variables["obs_hid"][:].astype(np.int64)
-        hdr_vld = nc.variables["hdr_vld"][:].astype(np.int64)
-        hdr_lat = nc.variables["hdr_lat"][:].astype(np.float32)
-        hdr_lon = nc.variables["hdr_lon"][:].astype(np.float32)
+        obs_val = nc.variables["obs_val"][:].astype(np.float32)   # mixed data
+        obs_vid = nc.variables["obs_vid"][:].astype(np.int64)     # variable ID
+        obs_hid = nc.variables["obs_hid"][:].astype(np.int64)     # connection key to connect val/vid to hdr_lat/hdr_lon/hdr_vld
+        hdr_vld = nc.variables["hdr_vld"][:].astype(np.int64)     # time index for lat and lon
+        hdr_lat = nc.variables["hdr_lat"][:].astype(np.float32)   # latitude
+        hdr_lon = nc.variables["hdr_lon"][:].astype(np.float32)   # longitude
 
         # Fix 1-based → 0-based if needed
         if obs_vid.min() == 1: obs_vid -= 1
         if obs_hid.min() == 1: obs_hid -= 1
         if hdr_vld.min() == 1: hdr_vld -= 1
 
-        # ── WSPA as MASTER ──────────────────────────────────────────────────
-        mask_master = (obs_vid == wsp_vid)
-        if not np.any(mask_master):
+        # create WSP table
+        mask_wsp = (obs_vid == wsp_vid)                           # find indexes of WSP for mapping WSP data in obs_val
+        if not np.any(mask_wsp):
             print(f"  Skip: no {WSP_MNEM} observations")
             continue
 
-        hid_master = obs_hid[mask_master]
-        wsp        = obs_val[mask_master]
-        lat        = hdr_lat[hid_master]
-        lon        = hdr_lon[hid_master]
-        # lon = ((lon + 180) % 360) - 180   # uncomment if you prefer -180/180
+        hid_wsp = obs_hid[mask_wsp]                               # connection keys of WSP for mapping lat, lon, and time
+        # create dataframe for WSP
+        df_wsp = pd.DataFrame({
+            "hid": hid_wsp,
+            "lat": hdr_lat[hid_wsp],                              # lat using connection key matching WSP
+            "lon": hdr_lon[hid_wsp],                              # lon using connection key matching WSP
+            "vld": hdr_vld[hid_wsp],                              # Store the time index here
+            "wsp": obs_val[mask_wsp]                              # WSP obs values
+        })
 
-        hv_master = hdr_vld[hid_master]
+        # Create the HS table separately to avoid losing data when using WSP as the master variable
+        mask_hs = (obs_vid == hs_vid)
+        if not np.any(mask_hs):
+            print(f"  Skip: no {HS_MNEM} observations")
+            continue
 
-        # Parse times
-        time_strs = [vld_table[int(j)].split()[0] if 0 <= int(j) < len(vld_table) else "" for j in hv_master]
-        times = np.full(len(hv_master), np.nan, dtype=np.float64)
+        hid_hs  = obs_hid[mask_hs]                                # connection keys of Hs for mapping lat, lon, and time
+        # create dataframe for HS
+        df_hs = pd.DataFrame({
+            "hid": hid_hs,
+            "lat": hdr_lat[hid_hs],                              # lat using connection key matching Hs
+            "lon": hdr_lon[hid_hs],                              # lon using connection key matching Hs
+            "vld": hdr_vld[hid_hs],                              # Store the time index here
+            "hs":  obs_val[mask_hs]                              # Hs obs values
+        })
+
+        # merge WSP and HS
+        df = pd.merge(df_wsp, df_hs, on=["hid", "lat", "lon", "vld"], how="outer")
+
+        # fill in the timestamps based on vld
+        time_strs = [vld_table[int(j)].split()[0] if 0 <= int(j) < len(vld_table) else "" for j in df["vld"]]
+        times = np.full(len(df), np.nan, dtype=np.float64)       # convert yyyymmdd_hhmmss to unix timestamps
         for i, ts in enumerate(time_strs):
             if ts:
                 try:
@@ -112,29 +133,18 @@ for infile in infiles:
                 except:
                     pass
 
-        # ── Collocate KBSW (SWH) ────────────────────────────────────────────
-        hs = np.full_like(wsp, np.nan, dtype=np.float32)
-        if hs_vid is not None:
-            mask_hs = (obs_vid == hs_vid)
-            if np.any(mask_hs):
-                hid_hs = obs_hid[mask_hs]
-                val_hs = obs_val[mask_hs]
-                hid_to_hs = dict(zip(hid_hs, val_hs))
-                for i, h in enumerate(hid_master):
-                    hs[i] = hid_to_hs.get(h, np.nan)
+        df["time_unix"] = times
+        df["time_str"] = pd.to_datetime(df["time_unix"], unit="s", utc=True, errors="coerce").dt.strftime("%Y-%m-%d %H:%M:%S")
 
-        # ── Build DataFrame for debugging ───────────────────────────────────
-        df = pd.DataFrame({
-            "time_unix": times,
-            "time_str": pd.Series(pd.to_datetime(times, unit="s", utc=True, errors="coerce")).dt.strftime("%Y-%m-%d %H:%M:%S"),
-            "lat": lat,
-            "lon": lon,
-            "wsp": wsp,
-            "hs": hs,
-        })
+        df = df.drop(columns=["vld"])[["time_unix", "time_str", "lat", "lon", "wsp", "hs"]]
 
-        # Sort by time (NaNs at end)
-        df = df.sort_values("time_unix", na_position="last").reset_index(drop=True)
+        # sort the table by time (not necessary to move NaNs at end)
+        df = df.sort_values(by="time_unix", ascending=True)
+        df = df.reset_index(drop=True)
+
+        # QC - Physical Bounds Clipping: Wind Speed (m/s) 0.5 - 100; SWH (m) 0 - 50
+        df.loc[(df['wsp'] < 0.5) | (df['wsp'] > 100), 'wsp'] = np.nan   # values below 0.5 m/s sensor noise floor
+        df.loc[(df['hs'] < 0) | (df['hs'] > 50), 'hs']     = np.nan
 
         # Debug print
         n_total = len(df)
@@ -158,20 +168,21 @@ for infile in infiles:
         out.createDimension("time", n)
 
         vtime = out.createVariable("time", "f8", ("time",))
-        vlat  = out.createVariable("lat",  "f4", ("time",))
-        vlon  = out.createVariable("lon",  "f4", ("time",))
+        vlat  = out.createVariable("latitude",  "f4", ("time",))
+        vlon  = out.createVariable("longitude",  "f4", ("time",))
         vwsp  = out.createVariable("wsp",  "f4", ("time",))
         vhs   = out.createVariable("hs",   "f4", ("time",))
         vwspc = out.createVariable("wsp_cal", "f4", ("time",))
         vhsc  = out.createVariable("hs_cal",  "f4", ("time",))
 
-        vtime.units = "seconds since 1970-01-01 00:00:00 UTC"
-        vlat.units  = "degrees_north"
-        vlon.units  = "degrees_east"
-        vwsp.units  = "m s-1"
-        vhs.units   = "m"
-        vwspc.units = "m s-1"
-        vhsc.units  = "m"
+        vtime.units    = "seconds since 1970-01-01 00:00:00 UTC"
+        vtime.calendar = "standard"
+        vlat.units     = "degrees_north"
+        vlon.units     = "degrees_east"
+        vwsp.units     = "m s-1"
+        vhs.units      = "m"
+        vwspc.units    = "m s-1"
+        vhsc.units     = "m"
 
         vwsp.long_name  = "wind_speed"
         vhs.long_name   = "significant_wave_height"

--- a/ush/pb2nc_to_ww3tools.py
+++ b/ush/pb2nc_to_ww3tools.py
@@ -37,7 +37,7 @@ WSP_MNEM = "WSPA"
 
 # ========================
 PB2NC_DIR = os.path.join(WORKDIR, "processsatdata", "pb2nc_out")
-OUT_DIR   = os.path.join(WORKDIR, "processsatdata", "pb2nc_altimeter")
+OUT_DIR   = os.path.join(WORKDIR, "processsatdata", "out", SAT_NAME)
 
 os.makedirs(OUT_DIR, exist_ok=True)
 # Find input files
@@ -142,8 +142,8 @@ for infile in infiles:
         df = df.sort_values(by="time_unix", ascending=True)
         df = df.reset_index(drop=True)
 
-        # QC - Physical Bounds Clipping: Wind Speed (m/s) 0.5 - 100; SWH (m) 0 - 50
-        df.loc[(df['wsp'] < 0.5) | (df['wsp'] > 100), 'wsp'] = np.nan   # values below 0.5 m/s sensor noise floor
+        # QC - Physical Bounds Clipping: Wind Speed (m/s) 0 - 100; SWH (m) 0 - 50
+        df.loc[(df['wsp'] < 0) | (df['wsp'] > 100), 'wsp'] = np.nan   # values below 0.5 m/s sensor noise floor
         df.loc[(df['hs'] < 0) | (df['hs'] > 50), 'hs']     = np.nan
 
         # Debug print


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR improves the script that rewrites pb2nc NetCDF files into a WW3Tools-readable NetCDF format, with a focus on data integrity, basic quality control, and maintainability.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
-->
This PR improves:
1. Preserve Hs Data
Previously, wind speed (WSP) was used as the master variable, and significant wave height (Hs) was filled based on WSP availability. This approach could lead to unintended loss of valid Hs data. In this update, Hs is processed and stored independently, ensuring no loss of available Hs information.

2. Basic Physical Bounds Clipping
Added basic QC checks to constrain variables within physically reasonable ranges: Hs clipped to [0, 50] meters; Wind speed clipped to [0.5, 100] m/s. For wind speed, values below 0.5 m/s would be considered sensor noise floor. The clipped boundaries are consistent with ww3tools AODN processing [configuration](https://github.com/NOAA-EMC/WW3-tools/blob/develop/parm/configs_ursa/CRYOSAT2.yaml#L20-L24).

3. Improved Code Documentation
Added comments throughout the script to clarify logic, data handling steps, etc. Enhances readability and supports easier review and future maintenance.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3-tools/issues/<issue_number>
-->
- fixes issue #91 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Improve pb2nc to WW3Tools conversion: preserve Hs, add QC clipping, and enhance documentation
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
 
### Testing

* How were these changes tested?

1. Create a work directory (e.g., .../work)
2. Clone WW3-Tools in work and merge the branch
3. Start with convert preBUFR to NetCDF using `WW3-tools/ush/preBUFR_to_NetCDF.sh`
    - modify WORKDIR
    - modify IN_DIR: `IN_DIR="/scratch3/NCEPDEV/marine/Ming.Chen/ursa/preBUFR_filter/processsatdata/preBUFR"` which contains preBUFR files from 2025-05-01 to 2025-05-31.
    - run the script: `sbatch WW3-tools/ush/preBUFR_to_NetCDF.sh`. The output NetCDF files will be in work//processsatdata/pb2nc_out
4. Rewrite pb2nc NetCDF to ww3tools readable format using `WW3-tools/ush/pb2nc_to_ww3tools.py`
    - modify WORKDIR
    - load python environment (module use /scratch4/NCEPDEV/marine/Saeideh.Banihashemi/installs/python-modules/
                                                  module load ursa-env)
    - run the script. The output will be in `work/processsatdata/pb2nc_altimeter`

5. Validation:
    - I have validation script in `/scratch3/NCEPDEV/marine/Ming.Chen/ursa/preBUFR_filter/validation`
        - `validation.py` is the python script for plotting.
        - it compares AODN to preBUFR on May 1, 2025.
        - we can compare other days by changing `ds_prebufr`

my validation figures:
<img width="3600" height="1500" alt="hs_timeseries" src="https://github.com/user-attachments/assets/09d273a0-e6f6-4e87-b0a4-e9d55a8e155b" />

<img width="3600" height="1500" alt="hs_diff_timeseries" src="https://github.com/user-attachments/assets/92869070-47d0-475e-965e-5137208c4b69" />

<img width="1800" height="1800" alt="hs_scatter_timeseries" src="https://github.com/user-attachments/assets/c4ec3bde-6dab-4300-beb0-9aaf94475f34" />

<img width="3600" height="1500" alt="wsp_timeseries" src="https://github.com/user-attachments/assets/d52ce5d7-1cc7-4a25-b2e9-81b1d3c46f75" />

<img width="3600" height="1500" alt="wsp_diff_timeseries" src="https://github.com/user-attachments/assets/726d3b6f-ca01-4e17-ae2e-2161b9b7ee25" />

<img width="1800" height="1800" alt="wsp_scatter_timeseries" src="https://github.com/user-attachments/assets/6993cac9-7be3-4819-8596-5e5eae686439" />
