### PR TITLE
Corrected url for GSHHS after this database was removed from NCEI at NOAA

### DIFF
--- a/unst_msh_gen/regional/MeshGenDirectory/DownloadShapeFiles.sh
+++ b/unst_msh_gen/regional/MeshGenDirectory/DownloadShapeFiles.sh
@@ -13,8 +13,10 @@ wget --output-document tl_2023_us_coastline.zip https://www2.census.gov/geo/tige
 
 echo "Downloading Global Self-consistent, Hierarchical, High-resolution Shorelines (GSHHS)"
 #GSHHG global coastline data
-#wget --output-document gshhg-shp-2.3.7.zip http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip
-wget --output-document gshhg-shp-2.3.7.zip https://www.ngdc.noaa.gov/mgg/shorelines/data/gshhg/latest/gshhg-shp-2.3.7.zip
+#gshhg has been removed from https://www.ngdc.noaa.gov 
+#wget --output-document gshhg-shp-2.3.7.zip https://www.ngdc.noaa.gov/mgg/shorelines/data/gshhg/latest/gshhg-shp-2.3.7.zip
+#Apr 27 2026: Hello Keston -NCEI no longer distributes the GSHHG shoreline, though it can be found at https://www.soest.hawaii.edu/pwessel/gshhg/index.html
+wget --output-document gshhg-shp-2.3.7.zip https://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip
 
 echo "Downloading OpenStreetMap shoreline (OSM)"
 #OSM global coastline data


### PR DESCRIPTION


# Pull Request Summary
<!-- A short overview of the PR --> 
This changes the download url for the GSHHS coastline dataset after NCEI ceased to host it.   

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
-->

This changes the download url for the GSHHS coastline dataset after NCEI ceased to host it.   Script unst_msh_gen/regional/MeshGenDirectory/DownloadShapeFiles.sh now downloads GSHHS from /www.soest.hawaii.edu where it is still hosted.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3-tools/issues/<issue_number>
-->
fixes # https://github.com/NOAA-EMC/WW3-tools/issues/113

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->

Corrected url for GSHHS after changes in where the database is hosted.

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [X] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
 
### Testing

* How were these changes tested?

Tested the script:  unst_msh_gen/regional/MeshGenDirectory/DownloadShapeFiles.sh on Ursa

