### PR TITLE
Tool for creating ww3list.txt for model prediction directories used by modelBuoy_collocation.py

### DIFF
--- a/ush/create_ww3list.py
+++ b/ush/create_ww3list.py
@@ -1,0 +1,136 @@
+"""
+create_ww3list.py
+
+PURPOSE:
+    Create a WW3 model file list text file (ww3list.txt) for
+    modelBuoy_collocation.py.
+
+    The script searches model output directories based on:
+        - user-defined base data directory
+        - start date
+        - end date
+        - forecast cycles
+        - filename pattern
+
+    Existing files are written into the ww3list text file.
+    Missing files are reported to screen but do not stop execution.
+
+USAGE:
+    python create_ww3list.py \
+        -d /path/to/model/data \
+        -s YYYYMMDD \
+        -e YYYYMMDD \
+        -c 00 06 12 18 \
+        -p 'gfswave.t{cycle}z.bull_tar' \
+        -o /path/to/output/directory \
+        -f ww3list.txt
+
+OUTPUT:
+    Text file containing full paths of existing WW3 model files.
+
+NOTE:
+    The script assumes the following directory structure:
+
+        <data-dir>/gfs.YYYYMMDD/CC/wave/station/<filename>
+
+    where:
+        YYYYMMDD = date
+        CC       = cycle (00, 06, 12, 18)
+
+    The filename pattern must contain:
+        {cycle}
+
+    Example:
+        gfswave.t{cycle}z.bull_tar
+
+AUTOR and DATE:
+    05/12/2026: Ming Chen, first version
+
+"""
+
+import argparse
+from datetime import datetime, timedelta
+from pathlib import Path
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Create WW3 model file list for modelBuoy_collocation.py"
+    )
+
+    parser.add_argument("-d", "--data-dir", required=True,
+                        help="Base model data directory, e.g. /scratch3/.../Data/gfsv16")
+
+    parser.add_argument("-s", "--start-date", required=True,
+                        help="Start date in YYYYMMDD format")
+
+    parser.add_argument("-e", "--end-date", required=True,
+                        help="End date in YYYYMMDD format, inclusive")
+
+    parser.add_argument("-c", "--cycles", nargs="+", default=["00", "06", "12", "18"],
+                        help="Forecast cycles, e.g. 00 06 12 18")
+
+    parser.add_argument("-p", "--filename-pattern", default="gfswave.t{cycle}z.bull_tar",
+                        help="Filename pattern. Use {cycle}, e.g. gfswave.t{cycle}z.bull_tar")
+
+    parser.add_argument("-o", "--outdir", required=True,
+                        help="Directory to write ww3list text file")
+
+    parser.add_argument("-f", "--outfile", default="ww3list.txt",
+                        help="Output list filename")
+
+    return parser.parse_args()
+
+def main():
+    args = parse_args()
+
+    data_dir = Path(args.data_dir)
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    outfile = outdir / args.outfile
+
+    start = datetime.strptime(args.start_date, "%Y%m%d")
+    end = datetime.strptime(args.end_date, "%Y%m%d")
+
+    if end < start:
+        raise ValueError("end-date must be >= start-date")
+
+    files_written = 0
+    missing_files = 0
+
+    with outfile.open("w") as f:
+        current = start
+        while current <= end:
+            yyyymmdd = current.strftime("%Y%m%d")
+
+            for cycle in args.cycles:
+                cycle = cycle.zfill(2)
+
+                model_file = (
+                    data_dir
+                    / f"gfs.{yyyymmdd}"
+                    / cycle
+                    / "wave"
+                    / "station"
+                    / args.filename_pattern.format(cycle=cycle)
+                )
+
+                if model_file.is_file():
+                    f.write(str(model_file) + "\n")
+                    files_written += 1
+                    print(f"FOUND   : {model_file}")
+                else:
+                    missing_files += 1
+                    print(f"MISSING : {model_file}")
+
+            current += timedelta(days=1)
+
+    print("=====================================================")
+    print(f"WW3 list created: {outfile}")
+    print(f"Files written   : {files_written}")
+    print(f"Files missing   : {missing_files}")
+    print("=====================================================")
+
+
+if __name__ == "__main__":
+    main()

--- a/ush/run_create_ww3list.sh
+++ b/ush/run_create_ww3list.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+
+MACHINE="ursa"
+WORKDIR="/scratch4/NCEPDEV/marine/Ming.Chen/ww3tools_dev"
+
+SCRIPTDIR="${WORKDIR}/WW3-tools/ush"
+PY_SCRIPT="create_ww3list.py"
+
+DATA_DIR="/scratch3/NCEPDEV/climate/Jessica.Meixner/Data/gfsv16"
+
+START_DATE="20250501"
+END_DATE="20250510"
+
+CYCLES=("00" "06" "12" "18")
+
+FILENAME_PATTERN="gfswave.t{cycle}z.bull_tar"
+
+OUTDIR="${WORKDIR}/src"
+OUTFILE="ww3list.txt"
+
+
+if [[ "${MACHINE}" == "ursa" ]]; then
+    module use /scratch3/NCEPDEV/climate/Jessica.Meixner/general/modulefiles
+    module load ww3tools
+elif [[ "${MACHINE}" == "orion" || "${MACHINE}" == "hercules" ]]; then
+    module use /work2/noaa/marine/jmeixner/general/modulefiles
+    module load ww3tools
+else
+    echo "ERROR: Unsupported MACHINE='${MACHINE}'"
+    exit 1
+fi
+
+echo "====================================================="
+echo "Runtime configuration"
+echo "====================================================="
+echo "MACHINE            = ${MACHINE}"
+echo "WORKDIR            = ${WORKDIR}"
+echo "SCRIPTDIR          = ${SCRIPTDIR}"
+echo "DATA_DIR           = ${DATA_DIR}"
+echo "START_DATE         = ${START_DATE}"
+echo "END_DATE           = ${END_DATE}"
+echo "CYCLES             = ${CYCLES[*]}"
+echo "FILENAME_PATTERN   = ${FILENAME_PATTERN}"
+echo "OUTDIR             = ${OUTDIR}"
+echo "OUTFILE            = ${OUTFILE}"
+echo "====================================================="
+
+CMD=(
+    python -u "${SCRIPTDIR}/${PY_SCRIPT}"
+    -d "${DATA_DIR}"
+    -s "${START_DATE}"
+    -e "${END_DATE}"
+    -c "${CYCLES[@]}"
+    -p "${FILENAME_PATTERN}"
+    -o "${OUTDIR}"
+    -f "${OUTFILE}"
+)
+
+echo "COMMAND:"
+printf '%q ' "${CMD[@]}"
+echo
+echo "====================================================="
+
+"${CMD[@]}"
+
+echo "Done."
+


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR adds a new tool for creating `ww3list.txt`, which contains model prediction directories required as input for buoy data  processing using `modelBuoy_collocation.py`.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
-->
This PR adds two scripts
1. `create_ww3list.py`: A Python script that creates a WW3 model file list text file, `ww3list.txt`, for `modelBuoy_collocation.py`. The script searches model output directories based on:
- user-defined base data directory
- start date
- end date
- forecast cycles
- filename pattern

2. `run_create_ww3list.sh`: A wrapper script for running `create_ww3list.py` with all required input parameters.
### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3-tools/issues/<issue_number>
-->
N/A
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Tool for creating ww3list.txt for model prediction directories used by modelBuoy_collocation.py
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
 
### Testing

* How were these changes tested?
Modify parameters in run_create_ww3list.sh.
./run_create_ww3list.sh

A ww3list.txt (or user-defined filename) contains all bull_tar file directories.

